### PR TITLE
bsp/board.h: fix typo

### DIFF
--- a/bsp/board.h
+++ b/bsp/board.h
@@ -20,7 +20,7 @@
 
 //=========================== public ======================================
 
-void db_board_innit(void);
+void db_board_init(void);
 void db_board_setReg_ON(void);
 void db_board_setReg_OFF(void);
 


### PR DESCRIPTION
The build works but raises a warning because of the function declaration being implicit