### PR TITLE
01bsp_radio_txrx: add missing board.c (empty)

### DIFF
--- a/projects/01bsp_radio_txrx/board.c
+++ b/projects/01bsp_radio_txrx/board.c
@@ -1,0 +1,28 @@
+/**
+ * @file board.c
+ * @addtogroup BSP
+ *
+ * @brief  nRF52833-specific definition of the "board" bsp module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2022
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <nrf.h>
+
+#include "board.h"
+
+//=========================== defines =========================================
+
+//=========================== variables =========================================
+
+//=========================== public ==========================================
+
+/**
+ * @brief Turn ON the DotBot board.
+ */
+void db_board_init(void) {
+
+}

--- a/projects/dotbot-firmware.emProject
+++ b/projects/dotbot-firmware.emProject
@@ -655,6 +655,7 @@
       <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;asm;inc" />
       <file file_name="01bsp_radio_txrx.c" />
       <file file_name="../../bsp/nrf52833/radio.c" />
+      <file file_name="board.c" />
     </folder>
     <folder Name="System Files">
       <file file_name="../../nRF/SEGGER_THUMB_Startup.s" />


### PR DESCRIPTION
Otherwise building the master branch fails with an undefined symbol.