### PR TITLE
45 doc add development setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following instructions will guide through running the default remote control
 ### Download the firmware onto the boards
 
 
-1. Download the lastest releases (the .hex files) of the DotBot-firmware and of the Gateway firmware from
+1. Download the latest releases (the .hex files) of the DotBot-firmware and of the Gateway firmware from
 [here](https://github.com/DotBots/DotBot-firmware-fresh/releases)
 
 You should end up with 2 files named `03app_dotbot.hex` and `03app_dotbot_gateway.hex`.


### PR DESCRIPTION
This PR updates the README of the repo:
- change the main title to something more generic than the single dotbot application
- update the note about the download of hex files (since they will be automatically attached to a release and the names are deterministic)
- update the gateway buttons usage since they change compared to the previous version
- add notes about SEGGER embedded studio (download link, notes about the CMSIS 5 required packages)