### PR TITLE
SailBot: Send GPS data over radio

### DIFF
--- a/drv/protocol.h
+++ b/drv/protocol.h
@@ -27,6 +27,7 @@ typedef enum {
     DB_PROTOCOL_LH2_RAW_DATA  = 2,  ///< Lighthouse 2 raw data
     DB_PROTOCOL_LH2_LOCATION  = 3,  ///< Lighthouse processed locations
     DB_PROTOCOL_ADVERTISEMENT = 4,  ///< DotBot advertisements
+    DB_PROTOCOL_GPS_LOCATION  = 5,  ///< GPS data from SailBot
 } command_type_t;
 
 typedef enum {


### PR DESCRIPTION
This PR adds a simple functionality as part of the autonomous operation of the SailBot. It periodically sends the GPS data over radio within the control loop.