### PR TITLE
Dotbot: implement basic control loop for following a given list of waypoints

### DIFF
--- a/drv/protocol.h
+++ b/drv/protocol.h
@@ -20,6 +20,7 @@
 #define DB_SWARM_ID          (0x0000)              ///< Default swarm ID
 #define DB_BROADCAST_ADDRESS 0xffffffffffffffffUL  ///< Broadcast address
 #define DB_GATEWAY_ADDRESS   0x0000000000000000UL  ///< Gateway address
+#define DB_MAX_WAYPOINTS     (16)                  ///< Max number of waypoints
 
 typedef enum {
     DB_PROTOCOL_CMD_MOVE_RAW  = 0,  ///< Move raw command type
@@ -29,6 +30,7 @@ typedef enum {
     DB_PROTOCOL_ADVERTISEMENT = 4,  ///< DotBot advertisements
     DB_PROTOCOL_GPS_LOCATION  = 5,  ///< GPS data from SailBot
     DB_PROTOCOL_DOTBOT_DATA   = 6,  ///< DotBot specific data (for now location and direction)
+    DB_PROTOCOL_LH2_WAYPOINTS = 7,  ///< List of LH2 waypoints to follow
 } command_type_t;
 
 typedef enum {
@@ -63,6 +65,11 @@ typedef struct __attribute__((packed)) {
     uint32_t y;  ///< Y coordinate, multiplied by 1e6
     uint32_t z;  ///< Z coordinate, multiplied by 1e6
 } protocol_lh2_location_t;
+
+typedef struct __attribute__((packed)) {
+    uint8_t waypoints_length;                            ///< Number of available waypoints
+    protocol_lh2_location_t waypoints[DB_MAX_WAYPOINTS]; ///< Array containing lh2 waypoints
+} protocol_lh2_waypoints_t;
 
 //=========================== public ===========================================
 

--- a/drv/protocol.h
+++ b/drv/protocol.h
@@ -20,7 +20,7 @@
 #define DB_SWARM_ID          (0x0000)              ///< Default swarm ID
 #define DB_BROADCAST_ADDRESS 0xffffffffffffffffUL  ///< Broadcast address
 #define DB_GATEWAY_ADDRESS   0x0000000000000000UL  ///< Gateway address
-#define DB_MAX_WAYPOINTS     (16)                  ///< Max number of waypoints
+#define DB_MAX_WAYPOINTS     (8)                   ///< Max number of waypoints
 
 typedef enum {
     DB_PROTOCOL_CMD_MOVE_RAW  = 0,  ///< Move raw command type
@@ -30,13 +30,19 @@ typedef enum {
     DB_PROTOCOL_ADVERTISEMENT = 4,  ///< DotBot advertisements
     DB_PROTOCOL_GPS_LOCATION  = 5,  ///< GPS data from SailBot
     DB_PROTOCOL_DOTBOT_DATA   = 6,  ///< DotBot specific data (for now location and direction)
-    DB_PROTOCOL_LH2_WAYPOINTS = 7,  ///< List of LH2 waypoints to follow
+    DB_PROTOCOL_CONTROL_MODE  = 7,  ///< Robot remote control mode (automatic or manual)
+    DB_PROTOCOL_LH2_WAYPOINTS = 8,  ///< List of LH2 waypoints to follow
 } command_type_t;
 
 typedef enum {
     DotBot  = 0,  ///< DotBot application
     SailBot = 1,  ///< SailBot application
 } application_type_t;
+
+typedef enum {
+    ControlManual = 0,  ///< Manual mode
+    ControlAuto   = 1,  ///< Automatic mode
+} protocol_control_mode_t;
 
 typedef struct __attribute__((packed)) {
     uint64_t           dst;          ///< Destination address of this packet
@@ -67,8 +73,8 @@ typedef struct __attribute__((packed)) {
 } protocol_lh2_location_t;
 
 typedef struct __attribute__((packed)) {
-    uint8_t waypoints_length;                            ///< Number of available waypoints
-    protocol_lh2_location_t waypoints[DB_MAX_WAYPOINTS]; ///< Array containing lh2 waypoints
+    uint8_t                 length;                    ///< Number of waypoints
+    protocol_lh2_location_t points[DB_MAX_WAYPOINTS];  ///< Array containing a list of lh2 point coordinates
 } protocol_lh2_waypoints_t;
 
 //=========================== public ===========================================

--- a/drv/protocol.h
+++ b/drv/protocol.h
@@ -16,7 +16,7 @@
 
 //=========================== defines ==========================================
 
-#define DB_FIRMWARE_VERSION  (3)                   ///< Version of the firmware
+#define DB_FIRMWARE_VERSION  (4)                   ///< Version of the firmware
 #define DB_SWARM_ID          (0x0000)              ///< Default swarm ID
 #define DB_BROADCAST_ADDRESS 0xffffffffffffffffUL  ///< Broadcast address
 #define DB_GATEWAY_ADDRESS   0x0000000000000000UL  ///< Gateway address

--- a/projects/03app_dotbot/03app_dotbot.c
+++ b/projects/03app_dotbot/03app_dotbot.c
@@ -119,6 +119,10 @@ static void radio_callback(uint8_t *pkt, uint8_t len) {
                 _dotbot_vars.last_location.y = new_location.y;
                 _dotbot_vars.last_location.z = new_location.z;
             } break;
+            case DB_PROTOCOL_LH2_WAYPOINTS:
+            {
+                protocol_lh2_waypoints_t *target_waypoints = (protocol_lh2_waypoints_t *)cmd_ptr;
+            } break;
             default:
                 break;
         }

--- a/projects/03app_dotbot/03app_dotbot.c
+++ b/projects/03app_dotbot/03app_dotbot.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <stdio.h>
 // Include BSP headers
 #include "board.h"
 #include "device.h"
@@ -29,37 +30,32 @@
 
 #define TIMEOUT_CHECK_DELAY_TICKS      (17000)  ///< ~500 ms delay between packet received timeout checks
 #define DB_LH2_FULL_COMPUTATION        (0)
-#define DB_BUFFER_MAX_BYTES            (64U)   ///< Max bytes in UART receive buffer
+#define DB_BUFFER_MAX_BYTES            (255U)  ///< Max bytes in UART receive buffer
 #define DB_DIRECTION_THRESHOLD         (0.01)  ///< Threshold to update the direction
 #define DB_DIRECTION_INVALID           (-1000)
-#define DB_WAYPOINT_DISTANCE_THRESHOLD (0.05)  ///< Distance threshold towards a target waypoint
+#define DB_WAYPOINT_DISTANCE_THRESHOLD (100000) ///< Distance threshold towards a target waypoint
 #define DB_PID_SAMPLE_TIME_MS          (100)   ///< PID sample time in milliseconds
-#define DB_MAX_SPEED                   (50)    ///< Max speed in autonomous control mode
-
-typedef struct {
-    float x;
-    float y;
-    float z;
-} dotbot_lh2_location_t;
+#define DB_MAX_SPEED                   (65)    ///< Max speed in autonomous control mode
 
 typedef struct {
     uint32_t                 ts_last_packet_received;            ///< Last timestamp in microseconds a control packet was received
     db_lh2_t                 lh2;                                ///< LH2 device descriptor
     uint8_t                  radio_buffer[DB_BUFFER_MAX_BYTES];  ///< Internal buffer that contains the command to send (from buttons)
-    dotbot_lh2_location_t    last_location;                      ///< Last computed LH2 location received
+    protocol_lh2_location_t  last_location;                      ///< Last computed LH2 location received
     int16_t                  direction;                          ///< Current direction of the DotBot (angle in °)
     protocol_control_mode_t  control_mode;                       ///< Remote control mode
     protocol_lh2_waypoints_t waypoints;                          ///< List of waypoints
     uint8_t                  next_waypoint_idx;                  ///< Index of next waypoint to reach
     pid_t                    pid_angular;                        ///< PID used to compute the angular speed
+    bool                     update_control_loop;
 } dotbot_vars_t;
 
 //=========================== variables ========================================
 
 ///! PID gains
 static const pid_gains_t _pid_params = {
-    .kp = 5,
-    .ki = 2,
+    .kp = 0.5,
+    .ki = 0.2,
     .kd = 0,
 };
 
@@ -81,7 +77,7 @@ static dotbot_vars_t _dotbot_vars;
 
 static void _timeout_check(void);
 static void _advertise(void);
-static void _compute_direction(const dotbot_lh2_location_t *location, int16_t *direction);
+static void _compute_angle(const protocol_lh2_location_t *next, const protocol_lh2_location_t *origin, int16_t *angle);
 static void _update_control_loop(void);
 
 //=========================== callbacks ========================================
@@ -126,23 +122,18 @@ static void radio_callback(uint8_t *pkt, uint8_t len) {
             case DB_PROTOCOL_LH2_LOCATION:
             {
                 const protocol_lh2_location_t *location     = (const protocol_lh2_location_t *)cmd_ptr;
-                dotbot_lh2_location_t          new_location = {
-                             .x = (float)location->x / 1e6,
-                             .y = (float)location->y / 1e6,
-                             .z = (float)location->z / 1e6,
-                };
-                _compute_direction(&new_location, &_dotbot_vars.direction);
-                if (_dotbot_vars.direction != DB_DIRECTION_INVALID) {
-                    _dotbot_vars.last_location.x = new_location.x;
-                    _dotbot_vars.last_location.y = new_location.y;
-                    _dotbot_vars.last_location.z = new_location.z;
+                int16_t angle = -1000;
+                _compute_angle(location, &_dotbot_vars.last_location, &angle);
+                if (angle != DB_DIRECTION_INVALID) {
+                    _dotbot_vars.last_location.x = location->x;
+                    _dotbot_vars.last_location.y = location->y;
+                    _dotbot_vars.last_location.z = location->z;
+                    _dotbot_vars.direction = angle;
                 }
-                if (_dotbot_vars.control_mode == ControlAuto) {
-                    _update_control_loop();
-                    __NOP();
-                }
+                _dotbot_vars.update_control_loop = (_dotbot_vars.control_mode == ControlAuto);
             } break;
             case DB_PROTOCOL_CONTROL_MODE:
+            {
                 db_motors_set_speed(0, 0);
                 _dotbot_vars.control_mode = (protocol_control_mode_t)(*cmd_ptr);
                 if (_dotbot_vars.control_mode == ControlAuto) {
@@ -150,17 +141,18 @@ static void radio_callback(uint8_t *pkt, uint8_t len) {
                 } else {
                     db_pid_set_mode(&_dotbot_vars.pid_angular, DB_PID_MODE_MANUAL);
                 }
-                break;
+            } break;
             case DB_PROTOCOL_LH2_WAYPOINTS:
             {
                 _dotbot_vars.control_mode           = ControlManual;
-                protocol_lh2_waypoints_t *waypoints = (protocol_lh2_waypoints_t *)cmd_ptr;
-                _dotbot_vars.waypoints.length       = waypoints->length;
-                memcpy(_dotbot_vars.waypoints.points, waypoints->points, waypoints->length * sizeof(protocol_lh2_location_t));
+                _dotbot_vars.waypoints.length = (uint8_t)*cmd_ptr;
+                printf("LH2_WAYPOINTS received: %d\n", _dotbot_vars.waypoints.length);
+                memcpy(&_dotbot_vars.waypoints.points, cmd_ptr + 1, _dotbot_vars.waypoints.length * sizeof(protocol_lh2_location_t));
                 _dotbot_vars.next_waypoint_idx = 0;
                 _dotbot_vars.control_mode      = ControlAuto;
             } break;
             default:
+                printf("Unsupported message type\n");
                 break;
         }
     } while (0);
@@ -187,10 +179,11 @@ int main(void) {
     // Initialize the pids
     db_pid_init(&_dotbot_vars.pid_angular, 0.0, 0.0,
                 _pid_params.kp, _pid_params.ki, _pid_params.kd,
-                0, DB_MAX_SPEED, DB_PID_SAMPLE_TIME_MS, DB_PID_MODE_MANUAL, DB_PID_DIRECTION_DIRECT);
+                -10, 10, DB_PID_SAMPLE_TIME_MS, DB_PID_MODE_MANUAL, DB_PID_DIRECTION_DIRECT);
 
     // Set an invalid heading since the value is unknown on startup.
     _dotbot_vars.direction = DB_DIRECTION_INVALID;
+    _dotbot_vars.update_control_loop = false;
 
     while (1) {
         db_lh2_process_raw_data(&_dotbot_vars.lh2);
@@ -215,7 +208,12 @@ int main(void) {
             }
             db_lh2_start(&_dotbot_vars.lh2);
         }
-        db_timer_delay_ms(100);
+
+        if (_dotbot_vars.update_control_loop) {
+            _update_control_loop();
+            _dotbot_vars.update_control_loop = false;
+        }
+        db_timer_delay_ms(200);
     }
 
     // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.
@@ -225,31 +223,38 @@ int main(void) {
 //=========================== private functions ================================
 
 static void _update_control_loop(void) {
+    printf("Entering update control loop\n");
+
     if (_dotbot_vars.next_waypoint_idx >= _dotbot_vars.waypoints.length) {
+        printf("Last waypoint reached, stopping\n");
         db_motors_set_speed(0, 0);
         return;
     }
-    float dx               = ((float)_dotbot_vars.waypoints.points[_dotbot_vars.next_waypoint_idx].x / 1e6) - _dotbot_vars.last_location.x;
-    float dy               = ((float)_dotbot_vars.waypoints.points[_dotbot_vars.next_waypoint_idx].y / 1e6) - _dotbot_vars.last_location.y;
+    float dx               = ((float)_dotbot_vars.waypoints.points[_dotbot_vars.next_waypoint_idx].x - (float)_dotbot_vars.last_location.x) / 1e6;
+    float dy               = ((float)_dotbot_vars.waypoints.points[_dotbot_vars.next_waypoint_idx].y - (float)_dotbot_vars.last_location.y) / 1e6;
     float distanceToTarget = sqrtf(powf(dx, 2) + powf(dy, 2));
 
-    if (distanceToTarget < DB_WAYPOINT_DISTANCE_THRESHOLD) {
+    if ((uint32_t)(distanceToTarget * 1e6) < (uint32_t)DB_WAYPOINT_DISTANCE_THRESHOLD) {
         // Target waypoint is reached
         _dotbot_vars.next_waypoint_idx++;
-        return;
-    }
-
-    if (_dotbot_vars.direction == DB_DIRECTION_INVALID) {
+        printf("Switching to next waypoint %d at x: %i, y: %i\n", _dotbot_vars.next_waypoint_idx, _dotbot_vars.waypoints.points[_dotbot_vars.next_waypoint_idx].x, _dotbot_vars.waypoints.points[_dotbot_vars.next_waypoint_idx].y);
+    } else if (_dotbot_vars.direction == DB_DIRECTION_INVALID) {
+        ////printf("No direction, moving forward a bit\n");
         // Unknown direction, just move forward a bit
         db_motors_set_speed(DB_MAX_SPEED, DB_MAX_SPEED);
     } else {
+        printf("Updating motor speeds\n");
         // compute angle to target waypoint
-        int8_t sideFactor               = (dx > 0) ? -1 : 1;
-        float  angleToTarget            = sideFactor * acosf(dy / distanceToTarget) * 180 / M_PI;
-        _dotbot_vars.pid_angular.input  = (float)_dotbot_vars.direction;
-        _dotbot_vars.pid_angular.target = angleToTarget;
+        int16_t angleToTarget = 0;
+        _compute_angle(&_dotbot_vars.waypoints.points[_dotbot_vars.next_waypoint_idx], &_dotbot_vars.last_location, &angleToTarget);
+        _dotbot_vars.pid_angular.input  = (float)(_dotbot_vars.direction - angleToTarget);
+        printf("Direction: %i\n", _dotbot_vars.direction);
+        printf("Angle to target: %i\n", angleToTarget);
+        printf("PID input: %i\n", (int16_t)_dotbot_vars.pid_angular.input);
         db_pid_update(&_dotbot_vars.pid_angular);
         float   angularSpeed = _dotbot_vars.pid_angular.output;
+
+        printf("Computed angular speed: %i\n", (int16_t)angularSpeed);
         int16_t left         = (int16_t)((DB_MAX_SPEED - angularSpeed));
         int16_t right        = (int16_t)((DB_MAX_SPEED + angularSpeed));
         if (left > DB_MAX_SPEED) {
@@ -264,23 +269,22 @@ static void _update_control_loop(void) {
         if (left < -DB_MAX_SPEED) {
             left = -DB_MAX_SPEED;
         }
+        printf("Applying speeds: %i, %i\n", left, right);
         db_motors_set_speed(left, right);
     }
 }
 
-static void _compute_direction(const dotbot_lh2_location_t *location, int16_t *direction) {
-    float dx       = location->x - _dotbot_vars.last_location.x;
-    float dy       = location->y - _dotbot_vars.last_location.y;
+static void _compute_angle(const protocol_lh2_location_t *next, const protocol_lh2_location_t *origin, int16_t *angle) {
+    float dx       = ((float)next->x - (float)origin->x) / 1e6;
+    float dy       = ((float)next->y - (float)origin->y) / 1e6;
     float distance = sqrtf(powf(dx, 2) + powf(dy, 2));
 
     if (distance < DB_DIRECTION_THRESHOLD) {
-        // Skip computation if distance to last position is too small and set an unknown direction
-        _dotbot_vars.direction = DB_DIRECTION_INVALID;
         return;
     }
 
     int8_t sideFactor = (dx > 0) ? -1 : 1;
-    *direction        = (int16_t)(acosf(dy / distance) * 180 / M_PI) * sideFactor;
+    *angle        = (int16_t)(acosf(dy / distance) * 180 / M_PI) * sideFactor;
     __NOP();  // For debugging
 }
 

--- a/projects/03app_dotbot/03app_dotbot.c
+++ b/projects/03app_dotbot/03app_dotbot.c
@@ -33,9 +33,9 @@
 #define DB_BUFFER_MAX_BYTES            (255U)  ///< Max bytes in UART receive buffer
 #define DB_DIRECTION_THRESHOLD         (0.01)  ///< Threshold to update the direction
 #define DB_DIRECTION_INVALID           (-1000)
-#define DB_WAYPOINT_DISTANCE_THRESHOLD (100000) ///< Distance threshold towards a target waypoint
-#define DB_PID_SAMPLE_TIME_MS          (100)   ///< PID sample time in milliseconds
-#define DB_MAX_SPEED                   (65)    ///< Max speed in autonomous control mode
+#define DB_WAYPOINT_DISTANCE_THRESHOLD (100000)  ///< Distance threshold towards a target waypoint
+#define DB_PID_SAMPLE_TIME_MS          (100)     ///< PID sample time in milliseconds
+#define DB_MAX_SPEED                   (65)      ///< Max speed in autonomous control mode
 
 typedef struct {
     uint32_t                 ts_last_packet_received;            ///< Last timestamp in microseconds a control packet was received
@@ -121,14 +121,14 @@ static void radio_callback(uint8_t *pkt, uint8_t len) {
             } break;
             case DB_PROTOCOL_LH2_LOCATION:
             {
-                const protocol_lh2_location_t *location     = (const protocol_lh2_location_t *)cmd_ptr;
-                int16_t angle = -1000;
+                const protocol_lh2_location_t *location = (const protocol_lh2_location_t *)cmd_ptr;
+                int16_t                        angle    = -1000;
                 _compute_angle(location, &_dotbot_vars.last_location, &angle);
                 if (angle != DB_DIRECTION_INVALID) {
                     _dotbot_vars.last_location.x = location->x;
                     _dotbot_vars.last_location.y = location->y;
                     _dotbot_vars.last_location.z = location->z;
-                    _dotbot_vars.direction = angle;
+                    _dotbot_vars.direction       = angle;
                 }
                 _dotbot_vars.update_control_loop = (_dotbot_vars.control_mode == ControlAuto);
             } break;
@@ -144,7 +144,7 @@ static void radio_callback(uint8_t *pkt, uint8_t len) {
             } break;
             case DB_PROTOCOL_LH2_WAYPOINTS:
             {
-                _dotbot_vars.control_mode           = ControlManual;
+                _dotbot_vars.control_mode     = ControlManual;
                 _dotbot_vars.waypoints.length = (uint8_t)*cmd_ptr;
                 printf("LH2_WAYPOINTS received: %d\n", _dotbot_vars.waypoints.length);
                 memcpy(&_dotbot_vars.waypoints.points, cmd_ptr + 1, _dotbot_vars.waypoints.length * sizeof(protocol_lh2_location_t));
@@ -182,7 +182,7 @@ int main(void) {
                 -10, 10, DB_PID_SAMPLE_TIME_MS, DB_PID_MODE_MANUAL, DB_PID_DIRECTION_DIRECT);
 
     // Set an invalid heading since the value is unknown on startup.
-    _dotbot_vars.direction = DB_DIRECTION_INVALID;
+    _dotbot_vars.direction           = DB_DIRECTION_INVALID;
     _dotbot_vars.update_control_loop = false;
 
     while (1) {
@@ -247,16 +247,16 @@ static void _update_control_loop(void) {
         // compute angle to target waypoint
         int16_t angleToTarget = 0;
         _compute_angle(&_dotbot_vars.waypoints.points[_dotbot_vars.next_waypoint_idx], &_dotbot_vars.last_location, &angleToTarget);
-        _dotbot_vars.pid_angular.input  = (float)(_dotbot_vars.direction - angleToTarget);
+        _dotbot_vars.pid_angular.input = (float)(_dotbot_vars.direction - angleToTarget);
         printf("Direction: %i\n", _dotbot_vars.direction);
         printf("Angle to target: %i\n", angleToTarget);
         printf("PID input: %i\n", (int16_t)_dotbot_vars.pid_angular.input);
         db_pid_update(&_dotbot_vars.pid_angular);
-        float   angularSpeed = _dotbot_vars.pid_angular.output;
+        float angularSpeed = _dotbot_vars.pid_angular.output;
 
         printf("Computed angular speed: %i\n", (int16_t)angularSpeed);
-        int16_t left         = (int16_t)((DB_MAX_SPEED - angularSpeed));
-        int16_t right        = (int16_t)((DB_MAX_SPEED + angularSpeed));
+        int16_t left  = (int16_t)((DB_MAX_SPEED - angularSpeed));
+        int16_t right = (int16_t)((DB_MAX_SPEED + angularSpeed));
         if (left > DB_MAX_SPEED) {
             left = DB_MAX_SPEED;
         }
@@ -284,7 +284,7 @@ static void _compute_angle(const protocol_lh2_location_t *next, const protocol_l
     }
 
     int8_t sideFactor = (dx > 0) ? -1 : 1;
-    *angle        = (int16_t)(acosf(dy / distance) * 180 / M_PI) * sideFactor;
+    *angle            = (int16_t)(acosf(dy / distance) * 180 / M_PI) * sideFactor;
     __NOP();  // For debugging
 }
 

--- a/projects/03app_dotbot_gateway/03app_dotbot_gateway.c
+++ b/projects/03app_dotbot_gateway/03app_dotbot_gateway.c
@@ -21,7 +21,7 @@
 
 //=========================== defines ==========================================
 
-#define DB_BUFFER_MAX_BYTES (64U)        ///< Max bytes in UART receive buffer
+#define DB_BUFFER_MAX_BYTES (255U)       ///< Max bytes in UART receive buffer
 #define DB_UART_BAUDRATE    (1000000UL)  ///< UART baudrate used by the gateway
 
 typedef struct {

--- a/projects/dotbot-firmware.emProject
+++ b/projects/dotbot-firmware.emProject
@@ -1249,7 +1249,7 @@
       linker_memory_map_file="$(ProjectDir)/../../nRF/Device/MemoryMap/nRF52833_xxAA_MemoryMap.xml"
       linker_section_placement_file="$(ProjectDir)/../../nRF/flash_placement.xml"
       macros="NRFHeaderFile=$(PackagesDir)/../../nRF/Device/Include/nrf.h;DeviceHeaderFile=$(PackagesDir)/../../nRF/Device/Include/nrf52833.h;DeviceSystemFile=$(PackagesDir)/../../nRF/Device/Source/system_nrf52.c;DeviceVectorsFile=$(PackagesDir)/../../nRF/Device/Startup/ses_startup_nrf52833.s;DeviceLinkerScript=$(PackagesDir)/../../nRF/Device/Linker/ses_nrf52833_xxaa.icf;DeviceMemoryMap=$(PackagesDir)/../../nRF/Device/MemoryMap/nRF52833_xxAA_MemoryMap.xml;DeviceLibraryIdentifier=M4lf;DeviceFamily=nRF;Target=nRF52833_xxAA;Placement=Flash"
-      project_dependencies="00bsp_dotbot_board;00bsp_dotbot_motors;00bsp_dotbot_rgbled;00bsp_radio;00bsp_dotbot_lh2;00drv_dotbot_protocol;00bsp_timer;00drv_pid"
+      project_dependencies="00bsp_dotbot_board;00bsp_dotbot_motors;00bsp_dotbot_rgbled;00bsp_radio;00bsp_dotbot_lh2;00drv_dotbot_protocol;00bsp_timer"
       project_directory="03app_dotbot"
       project_type="Executable"
       target_reset_script="Reset();"

--- a/projects/dotbot-firmware.emProject
+++ b/projects/dotbot-firmware.emProject
@@ -1249,7 +1249,7 @@
       linker_memory_map_file="$(ProjectDir)/../../nRF/Device/MemoryMap/nRF52833_xxAA_MemoryMap.xml"
       linker_section_placement_file="$(ProjectDir)/../../nRF/flash_placement.xml"
       macros="NRFHeaderFile=$(PackagesDir)/../../nRF/Device/Include/nrf.h;DeviceHeaderFile=$(PackagesDir)/../../nRF/Device/Include/nrf52833.h;DeviceSystemFile=$(PackagesDir)/../../nRF/Device/Source/system_nrf52.c;DeviceVectorsFile=$(PackagesDir)/../../nRF/Device/Startup/ses_startup_nrf52833.s;DeviceLinkerScript=$(PackagesDir)/../../nRF/Device/Linker/ses_nrf52833_xxaa.icf;DeviceMemoryMap=$(PackagesDir)/../../nRF/Device/MemoryMap/nRF52833_xxAA_MemoryMap.xml;DeviceLibraryIdentifier=M4lf;DeviceFamily=nRF;Target=nRF52833_xxAA;Placement=Flash"
-      project_dependencies="00bsp_dotbot_board;00bsp_dotbot_motors;00bsp_dotbot_rgbled;00bsp_radio;00bsp_dotbot_lh2;00drv_dotbot_protocol;00bsp_timer"
+      project_dependencies="00bsp_dotbot_board;00bsp_dotbot_motors;00bsp_dotbot_rgbled;00bsp_radio;00bsp_dotbot_lh2;00drv_dotbot_protocol;00bsp_timer;00drv_pid"
       project_directory="03app_dotbot"
       project_type="Executable"
       target_reset_script="Reset();"


### PR DESCRIPTION
This also adds a new message type to allow to switch the dotbot between manual and automatic control modes.

The refresh rate of the LH2 position is divided by 2: every 100 ms instead of every 50 ms.
Concerning the control loop only the angular speed is adapted using a pid and the linear speed is kept constant for simplicity.

fixes #113 and fixes #121