### PR TITLE
bsp: add API for random number generator

### DIFF
--- a/bsp/nrf52833/rng.c
+++ b/bsp/nrf52833/rng.c
@@ -1,0 +1,35 @@
+/**
+ * @file rng.c
+ * @addtogroup BSP
+ *
+ * @brief  nRF52833-specific definition of the "rng" bsp module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+#include <nrf.h>
+#include <stdint.h>
+
+#include "rng.h"
+
+//=========================== public ===========================================
+
+void db_rng_init(void) {
+
+    // Enable bias correction, slower but uniform
+    NRF_RNG->CONFIG = (RNG_CONFIG_DERCEN_Enabled << RNG_CONFIG_DERCEN_Pos);
+
+    // Enable value ready event
+    NRF_RNG->INTENSET = (RNG_INTENSET_VALRDY_Enabled << RNG_INTENSET_VALRDY_Pos);
+
+    // Automatically stop when value is ready
+    NRF_RNG->SHORTS = (RNG_SHORTS_VALRDY_STOP_Enabled << RNG_SHORTS_VALRDY_STOP_Pos);
+}
+
+void db_rng_read(uint8_t *value) {
+    NRF_RNG->TASKS_START = 1;
+    while (NRF_RNG->EVENTS_VALRDY == 0) {};
+    *value                 = (uint8_t)NRF_RNG->VALUE;
+    NRF_RNG->EVENTS_VALRDY = 0;
+}

--- a/bsp/rng.h
+++ b/bsp/rng.h
@@ -1,0 +1,33 @@
+#ifndef __RNG_H
+#define __RNG_H
+
+/**
+ * @file rng.h
+ * @addtogroup BSP
+ *
+ * @brief  Cross-platform declaration "RNG" bsp module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include <stdint.h>
+
+//=========================== defines ==========================================
+
+//=========================== prototypes =======================================
+
+/**
+ * @brief Configure the random number generator (RNG)
+ */
+void db_rng_init(void);
+
+/**
+ * @brief Read a random value (8 bits)
+ *
+ * @param[out] value address of the output value
+ */
+void db_rng_read(uint8_t *value);
+
+#endif

--- a/projects/01bsp_rng/01bsp_rng.c
+++ b/projects/01bsp_rng/01bsp_rng.c
@@ -1,0 +1,34 @@
+/**
+ * @file 01bsp_rng.c
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @brief This is a short example of how to use the RNG api.
+ *
+ * @copyright Inria, 2022
+ *
+ */
+#include <nrf.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "rng.h"
+#include "timer_hf.h"
+
+//=========================== main =============================================
+
+/**
+ *  @brief The program starts executing here.
+ */
+int main(void) {
+    db_timer_hf_init();
+    db_rng_init();
+
+    while (1) {
+        uint8_t value;
+        db_rng_read(&value);
+        printf("Random value: %d\n", value);
+
+        db_timer_hf_delay_ms(100);
+    }
+
+    // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.
+    __NOP();
+}

--- a/projects/01bsp_rng/README.md
+++ b/projects/01bsp_rng/README.md
@@ -1,0 +1,8 @@
+# Example application using the rng bsp
+
+This application shows the usage of the random number generator, rng, API. After
+initialization the application prints random 8 bit numbers on stdio.
+
+Using Segger Studio, use the Segger RTT interface to get the output: start a
+debug session and run the application. The output is printed on the Segger
+studio terminal.

--- a/projects/dotbot-firmware.emProject
+++ b/projects/dotbot-firmware.emProject
@@ -103,6 +103,14 @@
     <file file_name="radio.c" />
     <file file_name="../radio.h" />
   </project>
+  <project Name="00bsp_rng">
+    <configuration
+      Name="Common"
+      project_directory="../bsp/nrf52833"
+      project_type="Library" />
+    <file file_name="rng.c" />
+    <file file_name="../rng.h" />
+  </project>
   <project Name="00bsp_timer">
     <configuration
       Name="Common"

--- a/projects/dotbot-firmware.emProject
+++ b/projects/dotbot-firmware.emProject
@@ -850,6 +850,69 @@
       </file>
     </folder>
   </project>
+  <project Name="01bsp_rng">
+    <configuration
+      Name="Common"
+      Placement="Flash"
+      arm_linker_heap_size="8192"
+      arm_linker_process_stack_size="0"
+      arm_linker_stack_size="8192"
+      arm_linker_variant="SEGGER"
+      arm_rtl_variant="SEGGER"
+      arm_simulator_memory_simulation_parameter="ROM1;0x00000000;0x00080000;RAM1;0x00800000;0x00020000;RAM2;0x20000000;0x00020000;"
+      arm_target_debug_interface_type="ADIv5"
+      arm_target_device_name="nRF52833_xxAA"
+      arm_target_interface_type="SWD"
+      c_preprocessor_definitions="FLASH_PLACEMENT=1"
+      debug_register_definition_file="$(ProjectDir)/../../nRF/nrf52833.svd"
+      debug_stack_pointer_start="__stack_end__"
+      debug_start_from_entry_point_symbol="No"
+      debug_target_connection="J-Link"
+      gcc_entry_point="Reset_Handler"
+      link_linker_script_file="$(ProjectDir)/../../nRF/Device/Linker/ses_nrf52833_xxaa.icf"
+      linker_memory_map_file="$(ProjectDir)/../../nRF/Device/MemoryMap/nRF52833_xxAA_MemoryMap.xml"
+      linker_section_placement_file="$(ProjectDir)/../../nRF/flash_placement.xml"
+      macros="NRFHeaderFile=$(PackagesDir)/../../nRF/Device/Include/nrf.h;DeviceHeaderFile=$(PackagesDir)/../../nRF/Device/Include/nrf52833.h;DeviceSystemFile=$(PackagesDir)/../../nRF/Device/Source/system_nrf52.c;DeviceVectorsFile=$(PackagesDir)/../../nRF/Device/Startup/ses_startup_nrf52833.s;DeviceLinkerScript=$(PackagesDir)/../../nRF/Device/Linker/ses_nrf52833_xxaa.icf;DeviceMemoryMap=$(PackagesDir)/../../nRF/Device/MemoryMap/nRF52833_xxAA_MemoryMap.xml;DeviceLibraryIdentifier=M4lf;DeviceFamily=nRF;Target=nRF52833_xxAA;Placement=Flash"
+      project_dependencies="00bsp_rng;00bsp_timer_hf"
+      project_directory="01bsp_rng"
+      project_type="Executable"
+      target_reset_script="Reset();"
+      target_script_file="$(ProjectDir)/../../nRF_Target.js"
+      target_trace_initialize_script="EnableTrace(&quot;$(TraceInterfaceType)&quot;)" />
+    <folder Name="Device Files">
+      <file file_name="../../nRF/Device/Include/nrf.h" />
+      <file file_name="../../nRF/Device/Include/nrf52833.h" />
+      <file file_name="../../nRF/Device/Source/system_nrf52.c">
+        <file file_name="../../nRF/Device/Include/nrf.h" />
+        <configuration
+          Name="Common"
+          default_code_section=".init"
+          default_const_section=".init_rodata" />
+      </file>
+    </folder>
+    <folder Name="Script Files">
+      <file file_name="../../nRF/Scripts/nRF_Target.js">
+        <configuration Name="Common" file_type="Reset Script" />
+      </file>
+      <file file_name="../../nRF/Device/Linker/ses_nrf52833_xxaa.icf">
+        <configuration Name="Common" file_type="Linker Script" />
+      </file>
+      <file file_name="../../nRF/Device/MemoryMap/nRF52833_xxAA_MemoryMap.xml">
+        <configuration Name="Common" file_type="Memory Map" />
+      </file>
+    </folder>
+    <folder Name="Source Files">
+      <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;asm;inc" />
+      <file file_name="01bsp_rng.c" />
+    </folder>
+    <folder Name="System Files">
+      <file file_name="../../nRF/SEGGER_THUMB_Startup.s" />
+      <file file_name="../../nRF/Device/Startup/ses_startup_nrf_common.s" />
+      <file file_name="../../nRF/Device/Startup/ses_startup_nrf52833.s">
+        <configuration Name="Common" file_type="Assembly" />
+      </file>
+    </folder>
+  </project>
   <project Name="01bsp_rpm">
     <configuration
       Name="Common"


### PR DESCRIPTION
This adds a simple API to make use of the RNG peripheral on the nrf52.

fixes #101 