### PR TITLE
dotbot-gateway: refactor to do less things in ISR

### DIFF
--- a/bsp/nrf52833/uart.c
+++ b/bsp/nrf52833/uart.c
@@ -117,6 +117,7 @@ void db_uart_init(const gpio_t *rx_pin, const gpio_t *tx_pin, uint32_t baudrate,
         DB_UARTE->SHORTS        = (UARTE_SHORTS_ENDRX_STARTRX_Enabled << UARTE_SHORTS_ENDRX_STARTRX_Pos);
         DB_UARTE->TASKS_STARTRX = 1;
         NVIC_EnableIRQ(DB_UARTE_IRQ);
+        NVIC_SetPriority(DB_UARTE_IRQ, 0);
     }
 }
 

--- a/projects/03app_dotbot_gateway/03app_dotbot_gateway.c
+++ b/projects/03app_dotbot_gateway/03app_dotbot_gateway.c
@@ -21,16 +21,36 @@
 
 //=========================== defines ==========================================
 
-#define DB_BUFFER_MAX_BYTES (255U)       ///< Max bytes in UART receive buffer
-#define DB_UART_BAUDRATE    (1000000UL)  ///< UART baudrate used by the gateway
+#define DB_BUFFER_MAX_BYTES (255U)                           ///< Max bytes in UART receive buffer
+#define DB_UART_BAUDRATE    (1000000UL)                      ///< UART baudrate used by the gateway
+#define DB_RADIO_QUEUE_SIZE (8U)                             ///< Size of the radio queue (must by a power of 2)
+#define DB_UART_QUEUE_SIZE  ((DB_BUFFER_MAX_BYTES + 1) * 2)  ///< Size of the UART queue size (must by a power of 2)
 
 typedef struct {
-    db_hdlc_state_t hdlc_state;                               ///< Current state of the HDLC decoding engine
-    uint8_t         hdlc_rx_buffer[DB_BUFFER_MAX_BYTES * 2];  ///< Buffer where message received on UART is stored
-    uint8_t         hdlc_tx_buffer[DB_BUFFER_MAX_BYTES * 2];  ///< Internal buffer used for sending serial HDLC frames
-    uint32_t        buttons;                                  ///< Buttons state (one byte per button)
-    uint8_t         radio_tx_buffer[DB_BUFFER_MAX_BYTES];     ///< Internal buffer that contains the command to send (from buttons)
-    uint8_t         radio_rx_buffer[DB_BUFFER_MAX_BYTES];     ///< Internal buffer that contains the command to send (from buttons)
+    uint8_t length;                       ///< Length of the radio packet
+    uint8_t buffer[DB_BUFFER_MAX_BYTES];  ///< Buffer containing the radio packet
+} gateway_radio_packet_t;
+
+typedef struct {
+    uint8_t                current;                       ///< Current position in the queue
+    uint8_t                last;                          ///< Position of the last item added in the queue
+    gateway_radio_packet_t packets[DB_RADIO_QUEUE_SIZE];  ///< Buffer containing the received bytes
+} gateway_radio_packet_queue_t;
+
+typedef struct {
+    uint16_t current;                     ///< Current position in the queue
+    uint16_t last;                        ///< Position of the last item added in the queue
+    uint8_t  buffer[DB_UART_QUEUE_SIZE];  ///< Buffer containing the received bytes
+} gateway_uart_queue_t;
+
+typedef struct {
+    db_hdlc_state_t              hdlc_state;                               ///< Current state of the HDLC decoding engine
+    uint8_t                      hdlc_rx_buffer[DB_BUFFER_MAX_BYTES * 2];  ///< Buffer where message received on UART is stored
+    uint8_t                      hdlc_tx_buffer[DB_BUFFER_MAX_BYTES * 2];  ///< Internal buffer used for sending serial HDLC frames
+    uint32_t                     buttons;                                  ///< Buttons state (one byte per button)
+    uint8_t                      radio_tx_buffer[DB_BUFFER_MAX_BYTES];     ///< Internal buffer that contains the command to send (from buttons)
+    gateway_radio_packet_queue_t radio_queue;                              ///< Queue used to process received radio packets outside of interrupt
+    gateway_uart_queue_t         uart_queue;                               ///< Queue used to process received UART bytes outside of interrupt
 } gateway_vars_t;
 
 //=========================== variables ========================================
@@ -47,30 +67,14 @@ static void _init_buttons(void);
 //=========================== callbacks ========================================
 
 static void uart_callback(uint8_t data) {
-    _gw_vars.hdlc_state = db_hdlc_rx_byte(data);
-    switch ((uint8_t)_gw_vars.hdlc_state) {
-        case DB_HDLC_STATE_IDLE:
-        case DB_HDLC_STATE_RECEIVING:
-        case DB_HDLC_STATE_ERROR:
-            break;
-        case DB_HDLC_STATE_READY:
-        {
-            size_t msg_len = db_hdlc_decode(_gw_vars.hdlc_rx_buffer);
-            if (msg_len) {
-                _gw_vars.hdlc_state = DB_HDLC_STATE_IDLE;
-                db_radio_rx_disable();
-                db_radio_tx(_gw_vars.hdlc_rx_buffer, msg_len);
-                db_radio_rx_enable();
-            }
-        } break;
-        default:
-            break;
-    }
+    _gw_vars.uart_queue.buffer[_gw_vars.uart_queue.last] = data;
+    _gw_vars.uart_queue.last                             = (_gw_vars.uart_queue.last + 1) & (DB_UART_QUEUE_SIZE - 1);
 }
 
-void radio_callback(uint8_t *packet, uint8_t length) {
-    size_t frame_len = db_hdlc_encode(packet, length, _gw_vars.hdlc_tx_buffer);
-    db_uart_write(_gw_vars.hdlc_tx_buffer, frame_len);
+static void radio_callback(uint8_t *packet, uint8_t length) {
+    memcpy(_gw_vars.radio_queue.packets[_gw_vars.radio_queue.last].buffer, packet, length);
+    _gw_vars.radio_queue.packets[_gw_vars.radio_queue.last].length = length;
+    _gw_vars.radio_queue.last                                      = (_gw_vars.radio_queue.last + 1) & (DB_RADIO_QUEUE_SIZE - 1);
 }
 
 //=========================== main =============================================
@@ -86,7 +90,9 @@ int main(void) {
     db_radio_init(&radio_callback, DB_RADIO_BLE_1MBit);  // All RX packets received are forwarded in an HDLC frame over UART
     db_radio_set_frequency(8);                           // Set the radio frequency to 2408 MHz.
     // Initialize the gateway context
-    _gw_vars.buttons = 0x0000;
+    _gw_vars.buttons             = 0x0000;
+    _gw_vars.radio_queue.current = 0;
+    _gw_vars.radio_queue.last    = 0;
     db_uart_init(&_rx_pin, &_tx_pin, DB_UART_BAUDRATE, &uart_callback);
 
     db_radio_rx_enable();
@@ -119,7 +125,35 @@ int main(void) {
             db_radio_tx(_gw_vars.radio_tx_buffer, sizeof(protocol_header_t) + sizeof(protocol_move_raw_command_t));
             db_radio_rx_enable();
         }
-        db_timer_delay_ms(20);
+
+        while (_gw_vars.radio_queue.current != _gw_vars.radio_queue.last) {
+            size_t frame_len = db_hdlc_encode(_gw_vars.radio_queue.packets[_gw_vars.radio_queue.current].buffer, _gw_vars.radio_queue.packets[_gw_vars.radio_queue.current].length, _gw_vars.hdlc_tx_buffer);
+            db_uart_write(_gw_vars.hdlc_tx_buffer, frame_len);
+            _gw_vars.radio_queue.current = (_gw_vars.radio_queue.current + 1) & (DB_RADIO_QUEUE_SIZE - 1);
+        }
+
+        while (_gw_vars.uart_queue.current != _gw_vars.uart_queue.last) {
+            _gw_vars.hdlc_state = db_hdlc_rx_byte(_gw_vars.uart_queue.buffer[_gw_vars.uart_queue.current]);
+            switch ((uint8_t)_gw_vars.hdlc_state) {
+                case DB_HDLC_STATE_IDLE:
+                case DB_HDLC_STATE_RECEIVING:
+                case DB_HDLC_STATE_ERROR:
+                    break;
+                case DB_HDLC_STATE_READY:
+                {
+                    size_t msg_len = db_hdlc_decode(_gw_vars.hdlc_rx_buffer);
+                    if (msg_len) {
+                        _gw_vars.hdlc_state = DB_HDLC_STATE_IDLE;
+                        db_radio_rx_disable();
+                        db_radio_tx(_gw_vars.hdlc_rx_buffer, msg_len);
+                        db_radio_rx_enable();
+                    }
+                } break;
+                default:
+                    break;
+            }
+            _gw_vars.uart_queue.current = (_gw_vars.uart_queue.current + 1) & (DB_UART_QUEUE_SIZE - 1);
+        }
     }
 
     // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.


### PR DESCRIPTION
The UART interrupt priority is set to 0 to make sure no byte might be lost.