### PR TITLE
sailbot: add support for user defined waypoints received via protocol packets

### DIFF
--- a/drv/lis2mdl/lis2mdl.c
+++ b/drv/lis2mdl/lis2mdl.c
@@ -116,7 +116,10 @@ void lis2mdl_i2c_read_magnetometer(lis2mdl_compass_data_t *out) {
 
     // make sure that data is ready for read
     db_i2c_read_regs(LIS2MDL_ADDR, LIS2MDL_STATUS_REG, &tmp, 1);
-    assert((tmp & 0x8) != 0);
+
+    if ((tmp & 0x8) == 0) {
+        return;
+    }
 
     db_i2c_read_regs(LIS2MDL_ADDR, LIS2MDL_OUTX_L_REG, &tmp, 1);
     out->x = (int16_t)tmp;

--- a/drv/protocol.h
+++ b/drv/protocol.h
@@ -32,6 +32,7 @@ typedef enum {
     DB_PROTOCOL_DOTBOT_DATA   = 6,  ///< DotBot specific data (for now location and direction)
     DB_PROTOCOL_CONTROL_MODE  = 7,  ///< Robot remote control mode (automatic or manual)
     DB_PROTOCOL_LH2_WAYPOINTS = 8,  ///< List of LH2 waypoints to follow
+    DB_PROTOCOL_GPS_WAYPOINTS = 9,  ///< List of GPS waypoints to follow
 } command_type_t;
 
 typedef enum {
@@ -76,6 +77,16 @@ typedef struct __attribute__((packed)) {
     uint8_t                 length;                    ///< Number of waypoints
     protocol_lh2_location_t points[DB_MAX_WAYPOINTS];  ///< Array containing a list of lh2 point coordinates
 } protocol_lh2_waypoints_t;
+
+typedef struct __attribute__((packed)) {
+    int32_t latitude;   ///< Latitude, multiplied by 1e6
+    int32_t longitude;  ///< Longitude, multiplied by 1e6
+} protocol_gps_coordinate_t;
+
+typedef struct __attribute__((packed)) {
+    uint8_t                   length;                         ///< Number of waypoints
+    protocol_gps_coordinate_t coordinates[DB_MAX_WAYPOINTS];  ///< Array containing a list of GPS coordinates
+} protocol_gps_waypoints_t;
 
 //=========================== public ===========================================
 

--- a/projects/03app_sailbot/gps.c
+++ b/projects/03app_sailbot/gps.c
@@ -19,7 +19,7 @@
 
 //=========================== defines ==========================================
 
-#define GPS_UART_MAX_BYTES (83U)  ///< max bytes in UART receive buffer 82 bytes for NMEA + 1
+#define GPS_UART_MAX_BYTES (128U)  ///< max bytes in UART receive buffer, must be greater than 82 bytes for NMEA
 
 typedef struct {
     uint8_t      buffer[GPS_UART_MAX_BYTES];  ///< buffer where message received on UART is stored
@@ -218,8 +218,8 @@ uint8_t nmea_calculate_checksum(uint8_t *buffer) {
 }
 
 void gps_init(gps_rx_cb_t callback) {
-    // configure the module to output rate of 10 Hz
-    uint8_t nmea_cmd_set_10hz_data_rate[] = "$PMTK220,100*2F\r\n";
+    // configure the module to output rate of 1 Hz
+    uint8_t nmea_cmd_set_1hz_data_rate[] = "$PMTK220,1000*1F\r\n";
     // configure the module at 115200 bauds
     uint8_t nmea_cmd_set_baud_rate_115200[] = "$PMTK251,115200*1F\r\n";
     // enable only GPRMC sentences
@@ -243,8 +243,8 @@ void gps_init(gps_rx_cb_t callback) {
     db_uart_write(nmea_cmd_set_nmea_output, 51);
     db_timer_delay_ms(10);
 
-    // command to module to use 10hz output data rate
-    db_uart_write(nmea_cmd_set_10hz_data_rate, 17);
+    // command to module to use 1hz output data rate
+    db_uart_write(nmea_cmd_set_1hz_data_rate, 17);
 
     _gps_vars.callback = callback;
 }


### PR DESCRIPTION
The idea is to check if next waypoint is reached in the control_loop and not in the path planner callback. In the end, I just removed the path planner callback because it's simpler to do the GPS coordinates acquisition and check if the next waypoint is reached in the control loop.

fixes #131 