### PR TITLE
bsp: force constant latency power mode with uart and radio

### DIFF
--- a/bsp/nrf/radio.c
+++ b/bsp/nrf/radio.c
@@ -67,6 +67,11 @@ static void radio_init_addresses(void);
 
 void db_radio_init(radio_cb_t callback, db_radio_ble_mode_t mode) {
 
+#if defined(NRF5340_XXAA)
+    // On nrf53 configure constant latency mode for better performances
+    NRF_POWER_NS->TASKS_CONSTLAT = 1;
+#endif
+
     // Reset radio to its initial values
     NRF_RADIO->POWER = (RADIO_POWER_POWER_Disabled << RADIO_POWER_POWER_Pos);
     NRF_RADIO->POWER = (RADIO_POWER_POWER_Enabled << RADIO_POWER_POWER_Pos);

--- a/bsp/nrf/radio_nrf5340_app.c
+++ b/bsp/nrf/radio_nrf5340_app.c
@@ -52,6 +52,9 @@ static inline void _network_call(ipc_event_type_t req, ipc_event_type_t ack) {
 //=========================== public ===========================================
 
 void db_radio_init(radio_cb_t callback, db_radio_ble_mode_t mode) {
+    // On nrf53 configure constant latency mode for better performances
+    NRF_POWER_S->TASKS_CONSTLAT = 1;
+
     db_hfclk_init();
 
     // RADIO (address at 0x41008000 => periph ID is 8)

--- a/bsp/nrf/uart.c
+++ b/bsp/nrf/uart.c
@@ -22,10 +22,12 @@
 #define DB_UARTE     (NRF_UARTE1_S)
 #define DB_UARTE_IRQ (SERIAL1_IRQn)
 #define DB_UARTE_ISR (SERIAL1_IRQHandler)
+#define NRF_POWER    (NRF_POWER_S)
 #elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)
 #define DB_UARTE     (NRF_UARTE0_NS)
 #define DB_UARTE_IRQ (SERIAL0_IRQn)
 #define DB_UARTE_ISR (SERIAL0_IRQHandler)
+#define NRF_POWER    (NRF_POWER_NS)
 #else
 #define DB_UARTE     (NRF_UARTE0)
 #define DB_UARTE_IRQ (UARTE0_UART0_IRQn)
@@ -45,6 +47,11 @@ static uart_vars_t _uart_vars;  ///< variable handling the UART context
 //=========================== public ===========================================
 
 void db_uart_init(const gpio_t *rx_pin, const gpio_t *tx_pin, uint32_t baudrate, uart_rx_cb_t callback) {
+
+#if defined(NRF5340_XXAA)
+    // On nrf53 configure constant latency mode for better performances
+    NRF_POWER->TASKS_CONSTLAT = 1;
+#endif
 
     // configure UART pins (RX as input, TX as output);
     db_gpio_init(rx_pin, DB_GPIO_IN_PU);

--- a/projects/01bsp_uart/01bsp_uart.c
+++ b/projects/01bsp_uart/01bsp_uart.c
@@ -15,8 +15,8 @@
 
 //=========================== defines ==========================================
 
-#define DB_UART_MAX_BYTES (64U)      ///< max bytes in UART receive buffer
-#define DB_UART_BAUDRATE  (115200U)  ///< UART baudrate
+#define DB_UART_MAX_BYTES (64U)       ///< max bytes in UART receive buffer
+#define DB_UART_BAUDRATE  (1000000U)  ///< UART baudrate
 
 typedef struct {
     uint8_t buffer[DB_UART_MAX_BYTES];  ///< buffer where message received on UART is stored

--- a/projects/01bsp_uart/README.md
+++ b/projects/01bsp_uart/README.md
@@ -23,12 +23,12 @@ index 44aac55..7068b18 100644
 
 On the computer, use a terminal application to connect to the virtual communication
 port (/dev/ttyUSBxx on Linux, COMxx on Windows, etc) created by the UART to USB
-cable. The baudrate is 115200.
+cable. The baudrate is 1Mbaud.
 
 Example with [socat](http://www.dest-unreach.org/socat):
 
 ```
-socat - open:/dev/ttyACM0,b115200,echo=0,raw,cs8,parenb=0,cstopb=0
+socat - open:/dev/ttyACM0,b1000000,echo=0,raw,cs8,parenb=0,cstopb=0
 ```
 
 Loading this app onto the DotBot board will echo messages sent from the

--- a/projects/03app_dotbot_gateway/03app_dotbot_gateway.c
+++ b/projects/03app_dotbot_gateway/03app_dotbot_gateway.c
@@ -21,12 +21,8 @@
 
 //=========================== defines ==========================================
 
-#define DB_BUFFER_MAX_BYTES (255U)  ///< Max bytes in UART receive buffer
-#if defined(NRF5340_XXAA)
-#define DB_UART_BAUDRATE (460800UL)  ///< UART baudrate used by the gateway
-#else
-#define DB_UART_BAUDRATE (1000000UL)  ///< UART baudrate used by the gateway
-#endif
+#define DB_BUFFER_MAX_BYTES (255U)                           ///< Max bytes in UART receive buffer
+#define DB_UART_BAUDRATE    (1000000UL)                      ///< UART baudrate used by the gateway
 #define DB_RADIO_QUEUE_SIZE (8U)                             ///< Size of the radio queue (must by a power of 2)
 #define DB_UART_QUEUE_SIZE  ((DB_BUFFER_MAX_BYTES + 1) * 2)  ///< Size of the UART queue size (must by a power of 2)
 

--- a/projects/03app_nrf5340_app/main.c
+++ b/projects/03app_nrf5340_app/main.c
@@ -12,6 +12,9 @@
 
 int main(void) {
 
+    // On nrf53 configure constant latency mode for better performances
+    NRF_POWER_S->TASKS_CONSTLAT = 1;
+
     db_hfclk_init();
     db_lfclk_init();
 


### PR DESCRIPTION
This PR makes it possible to use UART at the highest baudrate (921600 and 1M baud). It also has a positive impact with radio.