### PR TITLE
nrf53: various improvements

### DIFF
--- a/bsp/nrf/radio.c
+++ b/bsp/nrf/radio.c
@@ -89,7 +89,12 @@ void db_radio_init(radio_cb_t callback, db_radio_ble_mode_t mode) {
     NRF_RADIO->MODE = ((RADIO_MODE_MODE_Ble_1Mbit + mode) << RADIO_MODE_MODE_Pos);  // Configure BLE mode
 #if defined(NRF5340_XXAA) && defined(NRF_NETWORK)
     // From errata v1.6 - 3.15 [117] RADIO: Changing MODE requires additional configuration
-    *((volatile uint32_t *)0x41008588) = *((volatile uint32_t *)0x01FF0080);
+    if (mode == DB_RADIO_BLE_2MBit) {
+        *((volatile uint32_t *)0x41008588) = *((volatile uint32_t *)0x01FF0084);
+    } else {
+        *((volatile uint32_t *)0x41008588) = *((volatile uint32_t *)0x01FF0080);
+    }
+
 #endif
 
     if (mode == DB_RADIO_BLE_1MBit || mode == DB_RADIO_BLE_2MBit) {

--- a/bsp/nrf/uart.c
+++ b/bsp/nrf/uart.c
@@ -49,8 +49,10 @@ static uart_vars_t _uart_vars;  ///< variable handling the UART context
 void db_uart_init(const gpio_t *rx_pin, const gpio_t *tx_pin, uint32_t baudrate, uart_rx_cb_t callback) {
 
 #if defined(NRF5340_XXAA)
-    // On nrf53 configure constant latency mode for better performances
-    NRF_POWER->TASKS_CONSTLAT = 1;
+    if (baudrate > 460800) {
+        // On nrf53 configure constant latency mode for better performances with high baudrates
+        NRF_POWER->TASKS_CONSTLAT = 1;
+    }
 #endif
 
     // configure UART pins (RX as input, TX as output);

--- a/projects/03app_nrf5340_net/main.c
+++ b/projects/03app_nrf5340_net/main.c
@@ -33,6 +33,12 @@ void radio_callback(uint8_t *packet, uint8_t length) {
 //=========================== main ==============================================
 
 int main(void) {
+
+#if defined(NRF5340_XXAA)
+    // Configure constant latency mode for better performances
+    NRF_POWER_NS->TASKS_CONSTLAT = 1;
+#endif
+
     NRF_IPC_NS->INTENSET                       = 1 << DB_IPC_CHAN_REQ;
     NRF_IPC_NS->SEND_CNF[DB_IPC_CHAN_ACK]      = 1 << DB_IPC_CHAN_ACK;
     NRF_IPC_NS->SEND_CNF[DB_IPC_CHAN_RADIO_RX] = 1 << DB_IPC_CHAN_RADIO_RX;


### PR DESCRIPTION
- correctly apply errata 117 when setting BLE mode
- force constant latency power mode only for high UART baudrate
- force constant latency power mode on network core when using companion application