### PR TITLE
bsp: add driver for Non Volatile Memory controller

### DIFF
--- a/bsp/bsp.emProject
+++ b/bsp/bsp.emProject
@@ -40,6 +40,14 @@
     <file file_name="nrf/motors.c" />
     <file file_name="motors.h" />
   </project>
+  <project Name="00bsp_nvmc">
+    <configuration
+      Name="Common"
+      project_directory="."
+      project_type="Library" />
+    <file file_name="nrf/nvmc.c" />
+    <file file_name="nvmc.h" />
+  </project>
   <project Name="00bsp_dotbot_rgbled">
     <configuration
       Name="Common"

--- a/bsp/nrf/nvmc.c
+++ b/bsp/nrf/nvmc.c
@@ -1,0 +1,67 @@
+/**
+ * @file nvmc.c
+ * @addtogroup BSP
+ *
+ * @brief  Implementation of the "nvmc" bsp module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "nrf.h"
+#include "nvmc.h"
+
+//=========================== defines =========================================
+
+#if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
+#define NRF_NVMC NRF_NVMC_S
+#elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)
+#define NRF_NVMC NRF_NVMC_NS
+#endif
+
+//=========================== public ==========================================
+
+void db_nvmc_read(void *output, const uint32_t *addr, size_t len) {
+
+    memcpy(output, addr, len);
+}
+
+void db_nvmc_page_erase(uint32_t page) {
+
+    assert(page < DB_FLASH_PAGE_NUM);
+
+    const uint32_t *addr = (const uint32_t *)(page * DB_FLASH_PAGE_SIZE + DB_FLASH_OFFSET);
+
+    NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Een << NVMC_CONFIG_WEN_Pos);
+#if defined(NRF5340_XXAA)
+    *(uint32_t *)addr = 0xFFFFFFFF;
+#else
+    NRF_NVMC->ERASEPAGE = (uint32_t)addr;
+#endif
+
+    while (!NRF_NVMC->READY) {}
+}
+
+void db_nvmc_write(const uint32_t *addr, const void *data, size_t len) {
+
+    // Length must be a multiple of 4 bytes
+    assert(len % 4 == 0);
+    // writes must be 4 bytes aligned
+    assert(!((uint32_t)addr % 4) && !((uint32_t)data % 4));
+
+    uint32_t       *dest_addr = (uint32_t *)addr;
+    const uint32_t *data_addr = data;
+
+    NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos);
+    for (uint32_t i = 0; i < (len >> 2); i++) {
+        *dest_addr++ = data_addr[i];
+    }
+
+    NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
+}

--- a/bsp/nvmc.h
+++ b/bsp/nvmc.h
@@ -1,0 +1,70 @@
+#ifndef __NVMC_H
+#define __NVMC_H
+
+/**
+ * @file nvmc.h
+ * @addtogroup BSP
+ *
+ * @brief  Cross-platform declaration "nvmc" bsp module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+
+//=========================== defines =========================================
+
+#if defined(NRF5340_XXAA) && defined(NRF_NETWORK)
+#define DB_FLASH_PAGE_SIZE 2048
+#else
+#define DB_FLASH_PAGE_SIZE 4096
+#endif
+
+#if defined(NRF5340_XXAA) && defined(NRF_NETWORK)
+#define DB_FLASH_OFFSET 0x01000000
+#else
+#define DB_FLASH_OFFSET 0x0
+#endif
+
+#if defined(NRF52840_XXAA)
+#define DB_FLASH_PAGE_NUM 256
+#elif defined(NRF52833_XXAA)
+#define DB_FLASH_PAGE_NUM 128
+#elif defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
+#define DB_FLASH_PAGE_NUM 256
+#elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)
+#define DB_FLASH_PAGE_NUM 128
+#else
+#error "Unsupported nRF CPU"
+#endif
+
+//=========================== public ==========================================
+
+/**
+ * @brief Read some data from a given address
+ * @param data  Pointer to the output buffer
+ * @param addr  Address to read from
+ * @param len   Length of data to read
+ */
+void db_nvmc_read(void *output, const uint32_t *addr, size_t len);
+
+/**
+ * @brief Erase a page on flash
+ *
+ * @param page  index of the page to erase
+ */
+void db_nvmc_page_erase(uint32_t page);
+
+/**
+ * @brief Write some data at a given address
+ *
+ * @param addr  Address to write to
+ * @param input Pointer to the intput buffer to write
+ * @param len   Length of data to write
+ */
+void db_nvmc_write(const uint32_t *addr, const void *input, size_t len);
+
+#endif

--- a/projects/01bsp_nvmc/01bsp_nvmc.c
+++ b/projects/01bsp_nvmc/01bsp_nvmc.c
@@ -1,0 +1,45 @@
+/**
+ * @file 01bsp_nvmc.c
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @brief This is a short example of how to use the nvmc api.
+ *
+ * @copyright Inria, 2023
+ *
+ */
+
+#include <nrf.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "nvmc.h"
+
+//=========================== defines ==========================================
+
+#define PAGE_INDEX (DB_FLASH_PAGE_NUM / 2)            ///< Page in the middle of the flash
+#define FLASH_ADDR (DB_FLASH_PAGE_SIZE * PAGE_INDEX)  ///< Address in flash corresponding to the page index
+
+//=========================== variables ========================================
+
+static const uint32_t *address    = (uint32_t *)(FLASH_ADDR + DB_FLASH_OFFSET);
+static const char     *message    = "Hello DotBot";
+static uint8_t         buffer[32] = { 0 };
+
+//=========================== main =============================================
+
+/**
+ *  @brief The program starts executing here.
+ */
+int main(void) {
+
+    // Whole page must be erased (written with 0xFF bytes) before new bytes can be written
+    db_nvmc_page_erase(PAGE_INDEX);
+    db_nvmc_write(address, message, strlen(message));
+    db_nvmc_read(buffer, address, strlen(message));
+
+    printf("Message written: %s\n", (char *)buffer, strlen(message));
+
+    while (1) {
+        __NOP();
+    }
+}

--- a/projects/01bsp_nvmc/README.md
+++ b/projects/01bsp_nvmc/README.md
@@ -1,0 +1,8 @@
+# Example application using the nvmc bsp
+
+This application shows the usage of the Non Volatile Memory controller, nvmc, API.
+This application erases a page on the flash, then writes some data there and read it.
+
+With Segger Studio, use the Segger RTT interface to get the output: start a
+debug session and run the application. The output is printed on the Segger
+studio terminal.

--- a/projects/03app_nrf5340_app/main.c
+++ b/projects/03app_nrf5340_app/main.c
@@ -69,6 +69,13 @@ int main(void) {
                                     SPU_PERIPHID_PERM_SECATTR_NonSecure << SPU_PERIPHID_PERM_SECATTR_Pos |
                                     SPU_PERIPHID_PERM_PRESENT_IsPresent << SPU_PERIPHID_PERM_PRESENT_Pos);
 
+    // Define FLASHREGION 62-64 as non secure (half of the network core flash)
+    for (uint8_t region = 62; region < 64; region++) {
+        NRF_SPU_S->FLASHREGION[region].PERM = (SPU_FLASHREGION_PERM_READ_Enable << SPU_FLASHREGION_PERM_READ_Pos |
+                                               SPU_FLASHREGION_PERM_WRITE_Enable << SPU_FLASHREGION_PERM_WRITE_Pos |
+                                               SPU_FLASHREGION_PERM_SECATTR_Non_Secure << SPU_FLASHREGION_PERM_SECATTR_Pos);
+    }
+
     // Configure non secure DPPI channels
     NRF_SPU_S->DPPI[0].PERM = 0;
 

--- a/projects/projects-bsp-drv.emProject
+++ b/projects/projects-bsp-drv.emProject
@@ -156,6 +156,45 @@
       </file>
     </folder>
   </project>
+  <project Name="01bsp_nvmc">
+    <configuration
+      Name="Common"
+      project_dependencies="00bsp_nvmc(bsp)"
+      project_directory="01bsp_nvmc"
+      project_type="Executable" />
+    <folder Name="Device Files">
+      <file file_name="$(DeviceHeaderFile)" />
+      <file file_name="$(DeviceCommonHeaderFile)" />
+      <file file_name="$(DeviceSystemFile)">
+        <configuration
+          Name="Common"
+          default_code_section=".init"
+          default_const_section=".init_rodata" />
+      </file>
+    </folder>
+    <folder Name="Script Files">
+      <file file_name="../../nRF/Scripts/nRF_Target.js">
+        <configuration Name="Common" file_type="Reset Script" />
+      </file>
+      <file file_name="$(DeviceLinkerScript)">
+        <configuration Name="Common" file_type="Linker Script" />
+      </file>
+      <file file_name="$(DeviceMemoryMap)">
+        <configuration Name="Common" file_type="Memory Map" />
+      </file>
+    </folder>
+    <folder Name="Source Files">
+      <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;asm;inc" />
+      <file file_name="01bsp_nvmc.c" />
+    </folder>
+    <folder Name="System Files">
+      <file file_name="$(SeggerThumbStartup)" />
+      <file file_name="$(DeviceCommonVectorsFile)" />
+      <file file_name="$(DeviceVectorsFile)">
+        <configuration Name="Common" file_type="Assembly" />
+      </file>
+    </folder>
+  </project>
   <project Name="01bsp_radio_lr_txrx">
     <configuration
       Name="Common"


### PR DESCRIPTION
It's very basic but it allows for erasing, writing and reading data on the flash memory. Where to write, when to erase is left to the user of this library.

It is working on nrf52840, nrf52833 and nrf5340 (application and network cores).

fixes #190 