### PR TITLE
Tilt-compensated heading

### DIFF
--- a/drv/drv.emProject
+++ b/drv/drv.emProject
@@ -49,6 +49,15 @@
     <file file_name="lsm6ds.c" />
     <file file_name="../lsm6ds.h" />
   </project>
+  <project Name="00drv_imu">
+    <configuration
+      Name="Common"
+      project_dependencies="00drv_lis2mdl(drv);00drv_lsm6ds(drv)"
+      project_directory="imu"
+      project_type="Library" />
+    <file file_name="imu.c" />
+    <file file_name="../imu.h" />
+  </project>
   <project Name="00drv_log_flash">
     <configuration
       Name="Common"

--- a/drv/imu.h
+++ b/drv/imu.h
@@ -1,0 +1,51 @@
+#ifndef __IMU_H
+#define __IMU_H
+
+/**
+ * @file imu.h
+ * @addtogroup sailbot
+ *
+ * @brief  Module for calculating the Euler angles (roll, pitch, yaw) of the SailBot.
+ *
+ * @author Mališa Vučinić <malisa.vucinic@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include "lis2mdl.h"
+#include "lsm6ds.h"
+
+/**
+ * @brief Calculate roll angle
+ *
+ * @param[in] acc_reading Raw accelerometer reading struct
+ * @return Roll angle
+ */
+float imu_calculate_roll(lsm6ds_acc_data_t *acc_reading);
+
+/**
+ * @brief Calculate pitch angle
+ *
+ * @param[in] acc_reading Raw accelerometer reading struct
+ * @return Pitch angle
+ */
+float imu_calculate_pitch(lsm6ds_acc_data_t *acc_reading);
+
+/**
+ * @brief Calculate uncompensated heading
+ *
+ * @param[in] mag_reading Raw magnetometer reading struct
+ * @return Heading angle
+ */
+float imu_calculate_uncompensated_heading(lis2mdl_compass_data_t *mag_reading);
+
+/**
+ * @brief Calculate tilt-compensated heading
+ *
+ * @param[in] mag_reading Raw magnetometer reading struct
+ * @param[in] acc_reading Raw accelerometer reading struct
+ * @return Tilt-compensated heading angle
+ */
+float imu_calculate_tilt_compensated_heading(lis2mdl_compass_data_t *mag_reading, lsm6ds_acc_data_t *acc_reading);
+
+#endif

--- a/drv/imu.h
+++ b/drv/imu.h
@@ -16,6 +16,14 @@
 #include "lsm6ds.h"
 
 /**
+ * @brief Initialize the IMU chips
+ *
+ * @param[in] lis2mdl_callback callback pointer invoked whenever LIS2MDL data is ready, can be NULL
+ * @param[in] lsm6ds_callback callback pointer invoked whenever LSM6DS data is ready, can be NULL
+ */
+void imu_init(lis2mdl_data_ready_cb_t lis2mdl_callback, lsm6ds_data_ready_cb_t lsm6ds_callback);
+
+/**
  * @brief Calculate roll angle
  *
  * @param[in] acc_reading Raw accelerometer reading struct

--- a/drv/imu/imu.c
+++ b/drv/imu/imu.c
@@ -1,0 +1,45 @@
+/**
+ * @file imu.c
+ * @author Mališa Vučinić <malisa.vucinic@inria.fr>
+ * @brief Module for calculating the Euler angles.
+ *
+ * @copyright Inria, 2023
+ *
+ */
+
+#include "math.h"
+#include "imu.h"
+
+float imu_calculate_roll(lsm6ds_acc_data_t *acc_reading) {
+    // return roll
+    return atan2f(-acc_reading->x, acc_reading->z);
+}
+
+float imu_calculate_pitch(lsm6ds_acc_data_t *acc_reading) {
+    // first calculate roll
+    float roll = imu_calculate_roll(acc_reading);
+    // then calculate pitch
+    float gz2 = (float)-acc_reading->x * sinf(roll) + (float)acc_reading->z * cosf(roll);
+    return atanf((float)acc_reading->y / gz2);
+}
+
+float imu_calculate_uncompensated_heading(lis2mdl_compass_data_t *mag_reading) {
+    // convert to heading
+    // atan2(x,y) for north-clockwise convention, + Pi for 0 to 2PI heading
+    return atan2f(mag_reading->x, mag_reading->y) + M_PI;
+}
+
+float imu_calculate_tilt_compensated_heading(lis2mdl_compass_data_t *mag_reading, lsm6ds_acc_data_t *acc_reading) {
+    // Discard the sign of roll and pitch
+    float roll  = fabsf(imu_calculate_roll(acc_reading));
+    float pitch = fabsf(imu_calculate_pitch(acc_reading));
+
+    float by2 = (float)mag_reading->z * sinf(roll) + (float)mag_reading->x * cosf(roll);
+    float bz2 = (float)-mag_reading->x * sinf(roll) + mag_reading->z * cosf(roll);
+
+    float bx3 = (float)mag_reading->y * cosf(pitch) + (float)bz2 * sinf(pitch);
+
+    float ret = atan2f(by2, bx3) + M_PI;
+
+    return ret;
+}

--- a/drv/imu/imu.c
+++ b/drv/imu/imu.c
@@ -10,6 +10,11 @@
 #include "math.h"
 #include "imu.h"
 
+void imu_init(lis2mdl_data_ready_cb_t lis2mdl_callback, lsm6ds_data_ready_cb_t lsm6ds_callback) {
+    lis2mdl_init(lis2mdl_callback);
+    lsm6ds_init(lsm6ds_callback);
+}
+
 float imu_calculate_roll(lsm6ds_acc_data_t *acc_reading) {
     // return roll
     return atan2f(-acc_reading->x, acc_reading->z);
@@ -31,15 +36,15 @@ float imu_calculate_uncompensated_heading(lis2mdl_compass_data_t *mag_reading) {
 
 float imu_calculate_tilt_compensated_heading(lis2mdl_compass_data_t *mag_reading, lsm6ds_acc_data_t *acc_reading) {
     // Discard the sign of roll and pitch
-    float roll  = fabsf(imu_calculate_roll(acc_reading));
-    float pitch = fabsf(imu_calculate_pitch(acc_reading));
+    float roll  = imu_calculate_roll(acc_reading);
+    float pitch = imu_calculate_pitch(acc_reading);
 
-    float by2 = (float)mag_reading->z * sinf(roll) + (float)mag_reading->x * cosf(roll);
-    float bz2 = (float)-mag_reading->x * sinf(roll) + mag_reading->z * cosf(roll);
+    float xh  = (float)mag_reading->z * sinf(roll) + (float)mag_reading->x * cosf(roll);
+    float bz2 = (float)-mag_reading->x * sinf(roll) + (float)mag_reading->z * cosf(roll);
 
-    float bx3 = (float)mag_reading->y * cosf(pitch) + (float)bz2 * sinf(pitch);
+    float yh = (float)mag_reading->y * cosf(pitch) + (float)bz2 * sinf(pitch);
 
-    float ret = atan2f(by2, bx3) + M_PI;
+    float ret = atan2f(xh, yh) + M_PI;
 
     return ret;
 }

--- a/drv/lis2mdl.h
+++ b/drv/lis2mdl.h
@@ -5,7 +5,7 @@
  * @file lis2mdl.h
  * @addtogroup sailbot
  *
- * @brief  Module for controlling the IMU on the SailBot.
+ * @brief  Module for reading the LIS2MDL magnetometer.
  *
  * @author Mališa Vučinić <malisa.vucinic@inria.fr>
  *
@@ -25,11 +25,23 @@ typedef struct {
 
 typedef void (*lis2mdl_data_ready_cb_t)(void);  ///< Callback function prototype, it is called on each available sample
 
-void  lis2mdl_init(lis2mdl_data_ready_cb_t callback);
-bool  lis2mdl_data_ready(void);
-void  lis2mdl_read_heading(void);
-float lis2mdl_last_uncompensated_heading(void);
-float lis2mdl_last_tilt_compensated_heading(float roll, float pitch);
-void  lis2mdl_magnetometer_calibrate(lis2mdl_compass_data_t *offset);
+/**
+ * @brief Initialize the LIS2MDL chip
+ *
+ * @param[in] callback       callback pointer invoked whenever data is ready
+ */
+void lis2mdl_init(lis2mdl_data_ready_cb_t callback);
+
+/**
+ * @brief Checks whether LIS2MDL data is ready for fetch
+ */
+bool lis2mdl_data_ready(void);
+
+/**
+ * @brief Reads magnetometer data on LIS2MDL over I2C
+ *
+ * @param[out] out Struct to write data to
+ */
+void lis2mdl_read_magnetometer(lis2mdl_compass_data_t *out);
 
 #endif

--- a/drv/lis2mdl.h
+++ b/drv/lis2mdl.h
@@ -28,7 +28,8 @@ typedef void (*lis2mdl_data_ready_cb_t)(void);  ///< Callback function prototype
 void  lis2mdl_init(lis2mdl_data_ready_cb_t callback);
 bool  lis2mdl_data_ready(void);
 void  lis2mdl_read_heading(void);
-float lis2mdl_last_heading(void);
+float lis2mdl_last_uncompensated_heading(void);
+float lis2mdl_last_tilt_compensated_heading(float roll, float pitch);
 void  lis2mdl_magnetometer_calibrate(lis2mdl_compass_data_t *offset);
 
 #endif

--- a/drv/lis2mdl/lis2mdl.c
+++ b/drv/lis2mdl/lis2mdl.c
@@ -137,7 +137,6 @@ void lis2mdl_i2c_read_magnetometer(lis2mdl_compass_data_t *out) {
     out->y -= SAILBOT_REV10_OFFSET_Y;
     out->z -= SAILBOT_REV10_OFFSET_Z;
 
-    //printf("Mx=%d My=%d Mz=%d\n",out->x, out->y, out->z);
     _lis2mdl_vars.data_ready = false;
 }
 
@@ -175,13 +174,13 @@ float lis2mdl_last_uncompensated_heading(void) {
 
 float lis2mdl_last_tilt_compensated_heading(float roll, float pitch) {
     // Discard the sign of roll and pitch
-    roll = fabsf(roll);
+    roll  = fabsf(roll);
     pitch = fabsf(pitch);
 
     float by2 = (float)_lis2mdl_vars.last_raw_data.z * sinf(roll) + (float)_lis2mdl_vars.last_raw_data.x * cosf(roll);
     float bz2 = (float)-_lis2mdl_vars.last_raw_data.x * sinf(roll) + _lis2mdl_vars.last_raw_data.z * cosf(roll);
 
-    float bx3 = (float)_lis2mdl_vars.last_raw_data.y * cosf(pitch) + (float) bz2 * sinf(pitch);
+    float bx3 = (float)_lis2mdl_vars.last_raw_data.y * cosf(pitch) + (float)bz2 * sinf(pitch);
 
     float ret = atan2f(by2, bx3) + M_PI;
 

--- a/drv/lis2mdl/lis2mdl.c
+++ b/drv/lis2mdl/lis2mdl.c
@@ -56,7 +56,6 @@ typedef struct {
     lis2mdl_data_ready_cb_t callback;
     bool                    data_ready;
     lis2mdl_compass_data_t  last_raw_data;
-    float                   uncompensated_heading;
 } lis2mdl_vars_t;
 
 //=========================== variables ========================================

--- a/drv/lis2mdl/lis2mdl.c
+++ b/drv/lis2mdl/lis2mdl.c
@@ -176,11 +176,12 @@ float lis2mdl_last_uncompensated_heading(void) {
 float lis2mdl_last_tilt_compensated_heading(float roll, float pitch) {
     // Discard the sign of roll and pitch
     roll = fabsf(roll);
-    //pitch += fabsf(pitch);
+    pitch = fabsf(pitch);
 
-    float by2 = (float)-_lis2mdl_vars.last_raw_data.z * sinf(roll) + (float)_lis2mdl_vars.last_raw_data.x * cosf(roll);
+    float by2 = (float)_lis2mdl_vars.last_raw_data.z * sinf(roll) + (float)_lis2mdl_vars.last_raw_data.x * cosf(roll);
+    float bz2 = (float)-_lis2mdl_vars.last_raw_data.x * sinf(roll) + _lis2mdl_vars.last_raw_data.z * cosf(roll);
 
-    float bx3 = (float)_lis2mdl_vars.last_raw_data.y;
+    float bx3 = (float)_lis2mdl_vars.last_raw_data.y * cosf(pitch) + (float) bz2 * sinf(pitch);
 
     float ret = atan2f(by2, bx3) + M_PI;
 

--- a/drv/lsm6ds.h
+++ b/drv/lsm6ds.h
@@ -46,6 +46,12 @@ void lsm6ds_read_accelerometer(void);
  * @brief Read the value of last roll angle
    @return Roll angle
  */
-int8_t lsm6ds_last_roll(void);
+float lsm6ds_last_roll(void);
+
+/**
+ * @brief Read the value of last pitch angle
+   @return Pitch angle
+ */
+float lsm6ds_last_pitch(void);
 
 #endif

--- a/drv/lsm6ds.h
+++ b/drv/lsm6ds.h
@@ -39,19 +39,9 @@ bool lsm6ds_data_ready(void);
 
 /**
  * @brief Reads accelerometer data on LSM6DS over I2C
+ *
+ * @param[out] out Struct to write data to
  */
-void lsm6ds_read_accelerometer(void);
-
-/**
- * @brief Read the value of last roll angle
-   @return Roll angle
- */
-float lsm6ds_last_roll(void);
-
-/**
- * @brief Read the value of last pitch angle
-   @return Pitch angle
- */
-float lsm6ds_last_pitch(void);
+void lsm6ds_read_accelerometer(lsm6ds_acc_data_t *out);
 
 #endif

--- a/drv/lsm6ds/lsm6ds.c
+++ b/drv/lsm6ds/lsm6ds.c
@@ -46,7 +46,8 @@ static const gpio_t imu_int = { .port = DB_LSM6DS_INT_PORT, .pin = DB_LSM6DS_INT
 typedef struct {
     lsm6ds_data_ready_cb_t callback;
     bool                   data_ready;
-    int16_t                roll;
+    float                  roll;
+    float                  pitch;
 } lsm6ds_vars_t;
 
 //=========================== variables ========================================
@@ -60,8 +61,12 @@ static void cb_imu_int(void *ctx);
 
 //============================== public ========================================
 
-int8_t lsm6ds_last_roll(void) {
+float lsm6ds_last_roll(void) {
     return _lsm6ds_vars.roll;
+}
+
+float lsm6ds_last_pitch(void) {
+    return _lsm6ds_vars.pitch;
 }
 
 bool lsm6ds_data_ready(void) {
@@ -107,7 +112,12 @@ void lsm6ds_read_accelerometer(void) {
     lsm6ds_i2c_read_accelerometer(&raw_data);
 
     // convert to roll angle
-    _lsm6ds_vars.roll = (int16_t)(atan2f(raw_data.x, raw_data.z) * 180 / M_PI);
+    _lsm6ds_vars.roll = atan2f(-raw_data.x, raw_data.z);
+
+    // convert to pitch angle
+    float gz2 = (float) -raw_data.x * sin(_lsm6ds_vars.roll) + (float) raw_data.z * cos(_lsm6ds_vars.roll);
+     _lsm6ds_vars.pitch = atanf((float) raw_data.y / gz2);
+
     return;
 }
 

--- a/drv/lsm6ds/lsm6ds.c
+++ b/drv/lsm6ds/lsm6ds.c
@@ -115,8 +115,8 @@ void lsm6ds_read_accelerometer(void) {
     _lsm6ds_vars.roll = atan2f(-raw_data.x, raw_data.z);
 
     // convert to pitch angle
-    float gz2 = (float) -raw_data.x * sin(_lsm6ds_vars.roll) + (float) raw_data.z * cos(_lsm6ds_vars.roll);
-     _lsm6ds_vars.pitch = atanf((float) raw_data.y / gz2);
+    float gz2          = (float)-raw_data.x * sin(_lsm6ds_vars.roll) + (float)raw_data.z * cos(_lsm6ds_vars.roll);
+    _lsm6ds_vars.pitch = atanf((float)raw_data.y / gz2);
 
     return;
 }

--- a/drv/lsm6ds/lsm6ds.c
+++ b/drv/lsm6ds/lsm6ds.c
@@ -46,8 +46,6 @@ static const gpio_t imu_int = { .port = DB_LSM6DS_INT_PORT, .pin = DB_LSM6DS_INT
 typedef struct {
     lsm6ds_data_ready_cb_t callback;
     bool                   data_ready;
-    float                  roll;
-    float                  pitch;
 } lsm6ds_vars_t;
 
 //=========================== variables ========================================
@@ -60,14 +58,6 @@ void        lsm6ds_i2c_read_accelerometer(lsm6ds_acc_data_t *out);
 static void cb_imu_int(void *ctx);
 
 //============================== public ========================================
-
-float lsm6ds_last_roll(void) {
-    return _lsm6ds_vars.roll;
-}
-
-float lsm6ds_last_pitch(void) {
-    return _lsm6ds_vars.pitch;
-}
 
 bool lsm6ds_data_ready(void) {
     return _lsm6ds_vars.data_ready;
@@ -106,18 +96,9 @@ void lsm6ds_init(lsm6ds_data_ready_cb_t callback) {
     lsm6ds_i2c_read_accelerometer(&dummy_data);
 }
 
-void lsm6ds_read_accelerometer(void) {
-    lsm6ds_acc_data_t raw_data;
+void lsm6ds_read_accelerometer(lsm6ds_acc_data_t *out) {
 
-    lsm6ds_i2c_read_accelerometer(&raw_data);
-
-    // convert to roll angle
-    _lsm6ds_vars.roll = atan2f(-raw_data.x, raw_data.z);
-
-    // convert to pitch angle
-    float gz2          = (float)-raw_data.x * sin(_lsm6ds_vars.roll) + (float)raw_data.z * cos(_lsm6ds_vars.roll);
-    _lsm6ds_vars.pitch = atanf((float)raw_data.y / gz2);
-
+    lsm6ds_i2c_read_accelerometer(out);
     return;
 }
 

--- a/projects/01drv_imu/01drv_imu.c
+++ b/projects/01drv_imu/01drv_imu.c
@@ -1,0 +1,66 @@
+/**
+ * @file 01drv_lis2mdl.c
+ * @author Mališa Vučinić <malisa.vucinic@inria.fr>
+ * @brief This is an example on how to use the IMU driver.
+ *
+ * @copyright Inria, 2023
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <nrf.h>
+#include <stdbool.h>
+
+// Include BSP packages
+#include "imu.h"
+#include "lis2mdl.h"
+#include "lsm6ds.h"
+
+//=========================== defines =========================================
+
+#define CONST_PI (3.14159265359f)
+
+typedef struct {
+} drv_imu_vars_t;
+
+//=========================== variables =========================================
+
+//=========================== prototypes =========================================
+
+//=========================== main =========================================
+
+/**
+ *  @brief The program starts executing here.
+ */
+int main(void) {
+    lis2mdl_compass_data_t mag = { 0 };
+    lsm6ds_acc_data_t      acc = { 0 };
+
+    // Init the magnetometer
+    lis2mdl_init(NULL);
+
+    // Init the IMU to read pitch and roll values to compensate heading
+    lsm6ds_init(NULL);
+
+    while (1) {
+        // processor idle until an interrupt occurs and is handled
+        if (lis2mdl_data_ready()) {
+            lis2mdl_read_magnetometer(&mag);
+        }
+        if (lsm6ds_data_ready()) {
+            lsm6ds_read_accelerometer(&acc);
+
+            float roll  = imu_calculate_roll(&acc);
+            float pitch = imu_calculate_pitch(&acc);
+
+            int16_t compensated_heading   = (int16_t)(imu_calculate_tilt_compensated_heading(&mag, &acc) * 180.0 / CONST_PI);
+            int16_t uncompensated_heading = (int16_t)(imu_calculate_uncompensated_heading(&mag) * 180.0 / CONST_PI);
+            printf("uncompensated=%d compensated=%d roll=%d pitch=%d\n", uncompensated_heading, compensated_heading, (int16_t)(roll * 180.0 / CONST_PI), (int16_t)(pitch * 180.0 / CONST_PI));
+        }
+        __WFE();
+    }
+    // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.
+    __NOP();
+}
+
+//=========================== functions =========================================

--- a/projects/01drv_imu/01drv_imu.c
+++ b/projects/01drv_imu/01drv_imu.c
@@ -23,10 +23,6 @@
 typedef struct {
 } drv_imu_vars_t;
 
-//=========================== variables =========================================
-
-//=========================== prototypes =========================================
-
 //=========================== main =========================================
 
 /**
@@ -36,11 +32,8 @@ int main(void) {
     lis2mdl_compass_data_t mag = { 0 };
     lsm6ds_acc_data_t      acc = { 0 };
 
-    // Init the magnetometer
-    lis2mdl_init(NULL);
-
-    // Init the IMU to read pitch and roll values to compensate heading
-    lsm6ds_init(NULL);
+    // Init the IMU chips
+    imu_init(NULL, NULL);
 
     while (1) {
         // processor idle until an interrupt occurs and is handled
@@ -62,5 +55,3 @@ int main(void) {
     // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.
     __NOP();
 }
-
-//=========================== functions =========================================

--- a/projects/01drv_lis2mdl/01drv_lis2mdl.c
+++ b/projects/01drv_lis2mdl/01drv_lis2mdl.c
@@ -59,11 +59,11 @@ int main(void) {
         }
         if (lsm6ds_data_ready()) {
             lsm6ds_read_accelerometer();
-            float roll = lsm6ds_last_roll();
-            float pitch = lsm6ds_last_pitch();
-            int16_t compensated_heading = (int16_t) (lis2mdl_last_tilt_compensated_heading(roll, pitch) * 180.0 / CONST_PI);
-            int16_t uncompensated_heading = (int16_t) (lis2mdl_last_uncompensated_heading() * 180.0 / CONST_PI);
-            printf("uncompensated=%d compensated=%d roll=%d pitch=%d\n", uncompensated_heading, compensated_heading, (int16_t) (roll * 180.0 / CONST_PI), (int16_t) (pitch * 180.0/CONST_PI));
+            float   roll                  = lsm6ds_last_roll();
+            float   pitch                 = lsm6ds_last_pitch();
+            int16_t compensated_heading   = (int16_t)(lis2mdl_last_tilt_compensated_heading(roll, pitch) * 180.0 / CONST_PI);
+            int16_t uncompensated_heading = (int16_t)(lis2mdl_last_uncompensated_heading() * 180.0 / CONST_PI);
+            printf("uncompensated=%d compensated=%d roll=%d pitch=%d\n", uncompensated_heading, compensated_heading, (int16_t)(roll * 180.0 / CONST_PI), (int16_t)(pitch * 180.0 / CONST_PI));
         }
         __WFE();
     }

--- a/projects/01drv_lis2mdl/01drv_lis2mdl.c
+++ b/projects/01drv_lis2mdl/01drv_lis2mdl.c
@@ -3,8 +3,7 @@
  * @author Mališa Vučinić <malisa.vucinic@inria.fr>
  * @brief This is an example on how to use the LIS2MDL driver.
  *
- * Load this program on your board, set CALIBRATION_PROCEDURE to 1 if calibration is needed.
- * With CALIBRATION_PROCEDURE set to 0, compass heading is printed as debug output.
+ * Raw compass values are continously printed as debug output.
  *
  * @copyright Inria, 2022
  *
@@ -21,9 +20,6 @@
 
 //=========================== defines =========================================
 
-#define CALIBRATION_PROCEDURE (0)
-#define CONST_PI              (3.14159265359f)
-
 typedef struct {
 } drv_lis2mdl_vars_t;
 
@@ -39,37 +35,16 @@ typedef struct {
 int main(void) {
     // Init the magnetometer
     lis2mdl_init(NULL);
-
-    // Init the IMU to read pitch and roll values to compensate heading
-    lsm6ds_init(NULL);
-
-#if CALIBRATION_PROCEDURE
-    lis2mdl_compass_data_t offset;
-
-    lis2mdl_magnetometer_calibrate(&offset);
-    while (1) {
-        ;
-    }
-#else
-
+    printf("X,Y,Z\n");
     while (1) {
         // processor idle until an interrupt occurs and is handled
         if (lis2mdl_data_ready()) {
-            lis2mdl_read_heading();
-        }
-        if (lsm6ds_data_ready()) {
-            lsm6ds_read_accelerometer();
-            float   roll                  = lsm6ds_last_roll();
-            float   pitch                 = lsm6ds_last_pitch();
-            int16_t compensated_heading   = (int16_t)(lis2mdl_last_tilt_compensated_heading(roll, pitch) * 180.0 / CONST_PI);
-            int16_t uncompensated_heading = (int16_t)(lis2mdl_last_uncompensated_heading() * 180.0 / CONST_PI);
-            printf("uncompensated=%d compensated=%d roll=%d pitch=%d\n", uncompensated_heading, compensated_heading, (int16_t)(roll * 180.0 / CONST_PI), (int16_t)(pitch * 180.0 / CONST_PI));
+            lis2mdl_compass_data_t mag;
+            lis2mdl_read_magnetometer(&mag);
+            printf("%d,%d,%d\n", mag.x, mag.y, mag.z);
         }
         __WFE();
     }
     // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.
     __NOP();
-#endif
 }
-
-//=========================== functions =========================================

--- a/projects/01drv_lsm6ds/01drv_lsm6ds.c
+++ b/projects/01drv_lsm6ds/01drv_lsm6ds.c
@@ -18,7 +18,7 @@
 
 #include "lsm6ds.h"
 
-#define CONST_PI              (3.14159265359f)
+#define CONST_PI (3.14159265359f)
 
 //=========================== main =========================================
 
@@ -33,8 +33,8 @@ int main(void) {
         // processor idle until an interrupt occurs and is handled
         if (lsm6ds_data_ready()) {
             lsm6ds_read_accelerometer();
-            int16_t roll = (int16_t) (lsm6ds_last_roll() * 180 / CONST_PI);
-            int16_t pitch = (int16_t) (lsm6ds_last_pitch() * 180 / CONST_PI);
+            int16_t roll  = (int16_t)(lsm6ds_last_roll() * 180 / CONST_PI);
+            int16_t pitch = (int16_t)(lsm6ds_last_pitch() * 180 / CONST_PI);
             printf("roll: %d pitch = %d\n", roll, pitch);
         }
         __WFE();

--- a/projects/01drv_lsm6ds/01drv_lsm6ds.c
+++ b/projects/01drv_lsm6ds/01drv_lsm6ds.c
@@ -3,8 +3,8 @@
  * @author Mališa Vučinić <malisa.vucinic@inria.fr>
  * @brief This is an example on how to use the LSM6DS driver.
  *
- * Load this program on your board in debug mode, roll will be continuously
- * printed.
+ * Load this program on your board in debug mode, accelerometer values will
+ * be printed continously.
  *
  * @copyright Inria, 2022
  *
@@ -18,8 +18,6 @@
 
 #include "lsm6ds.h"
 
-#define CONST_PI (3.14159265359f)
-
 //=========================== main =========================================
 
 /**
@@ -29,13 +27,13 @@ int main(void) {
     // Init the IMU
     lsm6ds_init(NULL);
 
+    printf("X,Y,Z\n");
     while (1) {
         // processor idle until an interrupt occurs and is handled
         if (lsm6ds_data_ready()) {
-            lsm6ds_read_accelerometer();
-            int16_t roll  = (int16_t)(lsm6ds_last_roll() * 180 / CONST_PI);
-            int16_t pitch = (int16_t)(lsm6ds_last_pitch() * 180 / CONST_PI);
-            printf("roll: %d pitch = %d\n", roll, pitch);
+            lsm6ds_acc_data_t acc;
+            lsm6ds_read_accelerometer(&acc);
+            printf("%d,%d,%d\n", acc.x, acc.y, acc.z);
         }
         __WFE();
     }

--- a/projects/01drv_lsm6ds/01drv_lsm6ds.c
+++ b/projects/01drv_lsm6ds/01drv_lsm6ds.c
@@ -18,14 +18,14 @@
 
 #include "lsm6ds.h"
 
+#define CONST_PI              (3.14159265359f)
+
 //=========================== main =========================================
 
 /**
  *  @brief The program starts executing here.
  */
 int main(void) {
-    int16_t roll;
-
     // Init the IMU
     lsm6ds_init(NULL);
 
@@ -33,8 +33,9 @@ int main(void) {
         // processor idle until an interrupt occurs and is handled
         if (lsm6ds_data_ready()) {
             lsm6ds_read_accelerometer();
-            roll = lsm6ds_last_roll();
-            printf("roll: %d\n", roll);
+            int16_t roll = (int16_t) (lsm6ds_last_roll() * 180 / CONST_PI);
+            int16_t pitch = (int16_t) (lsm6ds_last_pitch() * 180 / CONST_PI);
+            printf("roll: %d pitch = %d\n", roll, pitch);
         }
         __WFE();
     }

--- a/projects/03app_sailbot/03app_sailbot.c
+++ b/projects/03app_sailbot/03app_sailbot.c
@@ -225,7 +225,7 @@ void control_loop_callback(void) {
     }
 
     // get heading
-    float heading = lis2mdl_last_heading();
+    float heading = lis2mdl_last_uncompensated_heading();
 
     _send_gps_data(gps_data, (uint16_t)(heading * 180 / M_PI));
 

--- a/projects/03app_sailbot/03app_sailbot.c
+++ b/projects/03app_sailbot/03app_sailbot.c
@@ -117,11 +117,8 @@ int main(void) {
     db_radio_set_frequency(8);                           // Set the RX frequency to 2408 MHz.
     db_radio_rx_enable();                                // Start receiving packets.
 
-    // Init the magnetometer
-    lis2mdl_init(NULL);
-
-    // Init the accelerometer
-    lsm6ds_init(NULL);
+    // Init the IMU chips
+    imu_init(NULL, NULL);
 
     // Configure Motors
     servos_init();

--- a/projects/03app_sailbot/03app_sailbot.c
+++ b/projects/03app_sailbot/03app_sailbot.c
@@ -23,6 +23,7 @@
 #include "gps.h"
 #include "lis2mdl.h"
 #include "lsm6ds.h"
+#include "imu.h"
 #include "protocol.h"
 #include "timer.h"
 #include "timer_hf.h"
@@ -73,6 +74,8 @@ typedef struct {
     uint8_t                  radio_buffer[DB_BUFFER_MAX_BYTES];  ///< Internal buffer that contains the command to send (from buttons)
     bool                     autonomous_operation;               ///< Flag used to enable/disable autonomous operation
     bool                     radio_override;                     ///< Flag used to override autonomous operation when radio-controlled
+    lis2mdl_compass_data_t   last_magnetometer;                  ///< Last reading of the magnetometer
+    lsm6ds_acc_data_t        last_accelerometer;                 ///< Last reading of the accelerometer
 } sailbot_vars_t;
 
 //=========================== variables =========================================
@@ -142,10 +145,10 @@ int main(void) {
         // processor idle until an interrupt occurs and is handled
         // if IMU data is ready, trigger the I2C transfer from outside the interrupt context
         if (lis2mdl_data_ready()) {
-            lis2mdl_read_heading();
+            lis2mdl_read_magnetometer(&_sailbot_vars.last_magnetometer);
         }
         if (lsm6ds_data_ready()) {
-            lsm6ds_read_accelerometer();
+            lsm6ds_read_accelerometer(&_sailbot_vars.last_accelerometer);
         }
         __WFE();
     }
@@ -231,12 +234,8 @@ void control_loop_callback(void) {
         return;
     }
 
-    // get values of roll and pitch from the accelerometer
-    float roll  = lsm6ds_last_roll();
-    float pitch = lsm6ds_last_pitch();
-
     // get tilt-compensated heading
-    float heading = lis2mdl_last_tilt_compensated_heading(roll, pitch);
+    float heading = imu_calculate_tilt_compensated_heading(&_sailbot_vars.last_magnetometer, &_sailbot_vars.last_accelerometer);
 
     _send_gps_data(gps_data, (uint16_t)(heading * 180 / M_PI));
 

--- a/projects/projects-bsp-drv.emProject
+++ b/projects/projects-bsp-drv.emProject
@@ -549,7 +549,7 @@
   <project Name="01drv_lis2mdl">
     <configuration
       Name="Common"
-      project_dependencies="00drv_lis2mdl(drv);01drv_lsm6ds(projects-bsp-drv)"
+      project_dependencies="00drv_lis2mdl(drv)"
       project_directory="01drv_lis2mdl"
       project_type="Executable" />
     <folder Name="Device Files">
@@ -616,6 +616,46 @@
     <folder Name="Source Files">
       <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;asm;inc" />
       <file file_name="01drv_lsm6ds.c" />
+    </folder>
+    <folder Name="System Files">
+      <file file_name="$(SeggerThumbStartup)" />
+      <file file_name="$(DeviceCommonVectorsFile)" />
+      <file file_name="$(DeviceVectorsFile)">
+        <configuration Name="Common" file_type="Assembly" />
+      </file>
+    </folder>
+    <configuration Name="Debug" linker_printf_fp_enabled="Float" />
+  </project>
+  <project Name="01drv_imu">
+    <configuration
+      Name="Common"
+      project_dependencies="00drv_lis2mdl(drv);00drv_lsm6ds(drv);00drv_imu(drv)"
+      project_directory="01drv_imu"
+      project_type="Executable" />
+    <folder Name="Device Files">
+      <file file_name="$(DeviceHeaderFile)" />
+      <file file_name="$(DeviceCommonHeaderFile)" />
+      <file file_name="$(DeviceSystemFile)">
+        <configuration
+          Name="Common"
+          default_code_section=".init"
+          default_const_section=".init_rodata" />
+      </file>
+    </folder>
+    <folder Name="Script Files">
+      <file file_name="../../nRF/Scripts/nRF_Target.js">
+        <configuration Name="Common" file_type="Reset Script" />
+      </file>
+      <file file_name="$(DeviceLinkerScript)">
+        <configuration Name="Common" file_type="Linker Script" />
+      </file>
+      <file file_name="$(DeviceMemoryMap)">
+        <configuration Name="Common" file_type="Memory Map" />
+      </file>
+    </folder>
+    <folder Name="Source Files">
+      <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;asm;inc" />
+      <file file_name="01drv_imu.c" />
     </folder>
     <folder Name="System Files">
       <file file_name="$(SeggerThumbStartup)" />

--- a/projects/projects-bsp-drv.emProject
+++ b/projects/projects-bsp-drv.emProject
@@ -549,7 +549,7 @@
   <project Name="01drv_lis2mdl">
     <configuration
       Name="Common"
-      project_dependencies="00drv_lis2mdl(drv)"
+      project_dependencies="00drv_lis2mdl(drv);01drv_lsm6ds(projects-bsp-drv)"
       project_directory="01drv_lis2mdl"
       project_type="Executable" />
     <folder Name="Device Files">
@@ -586,7 +586,7 @@
     </folder>
     <configuration Name="Debug" linker_printf_fp_enabled="Float" />
   </project>
-   <project Name="01drv_lsm6ds">
+  <project Name="01drv_lsm6ds">
     <configuration
       Name="Common"
       project_dependencies="00drv_lsm6ds(drv)"

--- a/projects/projects-bsp-drv.emProject
+++ b/projects/projects-bsp-drv.emProject
@@ -629,7 +629,7 @@
   <project Name="01drv_imu">
     <configuration
       Name="Common"
-      project_dependencies="00drv_lis2mdl(drv);00drv_lsm6ds(drv);00drv_imu(drv)"
+      project_dependencies="00drv_imu(drv)"
       project_directory="01drv_imu"
       project_type="Executable" />
     <folder Name="Device Files">

--- a/projects/projects-sailbot.emProject
+++ b/projects/projects-sailbot.emProject
@@ -3,7 +3,7 @@
   <project Name="03app_sailbot">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_lis2mdl(drv)"
+      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_lis2mdl(drv);00drv_lsm6ds(drv)"
       project_directory="03app_sailbot"
       project_type="Executable" />
     <folder Name="Device Files">

--- a/projects/projects-sailbot.emProject
+++ b/projects/projects-sailbot.emProject
@@ -3,7 +3,7 @@
   <project Name="03app_sailbot">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_lis2mdl(drv);00drv_lsm6ds(drv)"
+      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_lis2mdl(drv);00drv_lsm6ds(drv);00drv_imu(drv)"
       project_directory="03app_sailbot"
       project_type="Executable" />
     <folder Name="Device Files">

--- a/projects/projects-sailbot.emProject
+++ b/projects/projects-sailbot.emProject
@@ -3,7 +3,7 @@
   <project Name="03app_sailbot">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_lis2mdl(drv);00drv_lsm6ds(drv);00drv_imu(drv)"
+      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_imu(drv)"
       project_directory="03app_sailbot"
       project_type="Executable" />
     <folder Name="Device Files">


### PR DESCRIPTION
The PR modifies LIS2MDL API to offer both uncompensated and tilt-compensated heading. I modify the example project of LIS2MDL to show how to use the tilt-compensated heading together with roll and pitch readings from the accelerometer.

Fixes #188 