### PR TITLE
projects/03app_dotbot: make log flash use optional (using a preprocessor define)

### DIFF
--- a/projects/03app_dotbot/03app_dotbot.c
+++ b/projects/03app_dotbot/03app_dotbot.c
@@ -152,7 +152,9 @@ static void radio_callback(uint8_t *pkt, uint8_t len) {
  */
 int main(void) {
     db_board_init();
+#ifdef ENABLE_DOTBOT_LOG_DATA
     db_log_flash_init(LOG_DATA_DOTBOT);
+#endif
     db_protocol_init();
     db_rgbled_init();
     db_motors_init();
@@ -285,6 +287,7 @@ static void _update_control_loop(void) {
 
     db_motors_set_speed(left_speed, right_speed);
 
+#ifdef ENABLE_DOTBOT_LOG_DATA
     // Log control loop internal data and output on flash
     _dotbot_vars.log_data.direction          = (int32_t)_dotbot_vars.direction;
     _dotbot_vars.log_data.pos_x              = _dotbot_vars.last_location.x;
@@ -297,6 +300,7 @@ static void _update_control_loop(void) {
     _dotbot_vars.log_data.left_speed         = left_speed;
     _dotbot_vars.log_data.right_speed        = right_speed;
     db_log_flash_write(&_dotbot_vars.log_data, sizeof(db_log_dotbot_data_t));
+#endif
 }
 
 static void _compute_angle(const protocol_lh2_location_t *next, const protocol_lh2_location_t *origin, int16_t *angle) {

--- a/projects/03app_log_dump/README.md
+++ b/projects/03app_log_dump/README.md
@@ -4,7 +4,7 @@ This application looks for log data stored on flash and dumps them to stdio.
 
 ## Usage
 
-To retrieve the logs, use  In Segger Embedded Studio as follows:
+To retrieve the logs, use Segger Embedded Studio as follows:
 1. Start a debug session (F5) and run the program (F5 again)
 2. Click inside the Debug Terminal window so it has focus, then press "s". The
 program will print the logs (or an error message if none is found and the version is


### PR DESCRIPTION
Using log flash has an impact on performance (especially with lighthouse) but is useful for debugging: let's use it on demand using a preprocessor macro at build time.