### PR TITLE
bsp: add support for qdec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ ifeq (nrf5340dk-app,$(BUILD_TARGET))
     01bsp_lighthouse \
     01bsp_motors \
     01bsp_nvmc \
+    01bsp_qdec \
     01bsp_radio_txrx \
     01bsp_radio_lr_txrx \
     01bsp_rgbled \
@@ -56,20 +57,25 @@ else
 endif
 
 # remove incompatible apps (nrf5340, sailbot gateway) for dotbot (v1, v2) builds
-ifneq (,$(filter dotbot-v%,$(BUILD_TARGET)))
-  PROJECTS := $(filter-out 03app_dotbot_gateway 03app_sailbot 03app_nrf5340_%,$(PROJECTS))
+ifneq (,$(filter dotbot-v1,$(BUILD_TARGET)))
+  PROJECTS := $(filter-out 01bsp_qdec 03app_dotbot_gateway 03app_sailbot 03app_nrf5340_%,$(PROJECTS))
+  ARTIFACT_PROJECTS := 03app_dotbot
+endif
+
+ifneq (,$(filter dotbot-v2,$(BUILD_TARGET)))
+  PROJECTS := $(filter-out 03app_dotbot_gateway 03app_sailbot 03app_nrf5340_net,$(PROJECTS))
   ARTIFACT_PROJECTS := 03app_dotbot
 endif
 
 # remove incompatible apps (nrf5340, dotbot, gateway) for sailbot-v1 build
 ifeq (sailbot-v1,$(BUILD_TARGET))
-  PROJECTS := $(filter-out 03app_dotbot_gateway 03app_dotbot 03app_nrf5340_%,$(PROJECTS))
+  PROJECTS := $(filter-out 01bsp_qdec 03app_dotbot_gateway 03app_dotbot 03app_nrf5340_%,$(PROJECTS))
   ARTIFACT_PROJECTS := 03app_sailbot
 endif
 
 # remove incompatible apps (nrf5340) for nrf52833dk/nrf52840dk build
 ifneq (,$(filter nrf52833dk nrf52840dk,$(BUILD_TARGET)))
-  PROJECTS := $(filter-out 03app_nrf5340_%,$(PROJECTS))
+  PROJECTS := $(filter-out 01bsp_qdec 03app_nrf5340_%,$(PROJECTS))
   ARTIFACT_PROJECTS ?= 03app_dotbot_gateway
 endif
 

--- a/bsp/board_config.h
+++ b/bsp/board_config.h
@@ -102,4 +102,26 @@ static const gpio_t db_rpm_right_pin = {
     .port = DB_RPM_RIGHT_PORT, .pin = DB_RPM_RIGHT_PORT
 };
 
+#ifdef DB_QDEC_LEFT_A_PORT
+///! Left wheel encoder pin A
+static const gpio_t db_qdec_left_a_pin = {
+    .port = DB_QDEC_LEFT_A_PORT, .pin = DB_QDEC_LEFT_A_PIN
+};
+
+///! Left wheel encoder pin B
+static const gpio_t db_qdec_left_b_pin = {
+    .port = DB_QDEC_LEFT_B_PORT, .pin = DB_QDEC_LEFT_B_PIN
+};
+
+///! Right wheel encoder pin A
+static const gpio_t db_qdec_right_a_pin = {
+    .port = DB_QDEC_RIGHT_A_PORT, .pin = DB_QDEC_RIGHT_A_PIN
+};
+
+///! Right wheel encoder pin B
+static const gpio_t db_qdec_right_b_pin = {
+    .port = DB_QDEC_RIGHT_B_PORT, .pin = DB_QDEC_RIGHT_B_PIN
+};
+#endif
+
 #endif

--- a/bsp/bsp.emProject
+++ b/bsp/bsp.emProject
@@ -91,6 +91,15 @@
     <file file_name="nrf/$(PwmImplementationFile)" />
     <file file_name="pwm.h" />
   </project>
+  <project Name="00bsp_qdec">
+    <configuration
+      Name="Common"
+      project_dependencies="00bsp_gpio"
+      project_directory="."
+      project_type="Library" />
+    <file file_name="nrf/qdec.c" />
+    <file file_name="qdec.h" />
+  </project>
   <project Name="00bsp_radio">
     <configuration
       Name="Common"

--- a/bsp/conf/dotbot_v2_config.h
+++ b/bsp/conf/dotbot_v2_config.h
@@ -107,6 +107,20 @@
 /** @} */
 
 /**
+ * @name    QDEC pins definitions
+ * @{
+ */
+#define DB_QDEC_LEFT_A_PORT  1
+#define DB_QDEC_LEFT_A_PIN   12
+#define DB_QDEC_LEFT_B_PORT  1
+#define DB_QDEC_LEFT_B_PIN   11
+#define DB_QDEC_RIGHT_A_PORT 0
+#define DB_QDEC_RIGHT_A_PIN  21
+#define DB_QDEC_RIGHT_B_PORT 0
+#define DB_QDEC_RIGHT_B_PIN  31
+/** @} */
+
+/**
  * @name    LSM6DS pin definitions
  * @{
  */

--- a/bsp/conf/nrf5340dk_config.h
+++ b/bsp/conf/nrf5340dk_config.h
@@ -107,6 +107,20 @@
 /** @} */
 
 /**
+ * @name    QDEC pins definitions
+ * @{
+ */
+#define DB_QDEC_LEFT_A_PORT  DB_BTN1_PORT
+#define DB_QDEC_LEFT_A_PIN   DB_BTN1_PIN
+#define DB_QDEC_LEFT_B_PORT  DB_BTN2_PORT
+#define DB_QDEC_LEFT_B_PIN   DB_BTN2_PIN
+#define DB_QDEC_RIGHT_A_PORT DB_BTN3_PORT
+#define DB_QDEC_RIGHT_A_PIN  DB_BTN3_PIN
+#define DB_QDEC_RIGHT_B_PORT DB_BTN4_PORT
+#define DB_QDEC_RIGHT_B_PIN  DB_BTN4_PIN
+/** @} */
+
+/**
  * @name    LSM6DS pin definitions
  * @{
  */

--- a/bsp/nrf/qdec.c
+++ b/bsp/nrf/qdec.c
@@ -1,0 +1,90 @@
+/**
+ * @file qdec.c
+ * @addtogroup BSP
+ *
+ * @brief  nRF5340-specific definition of the "qdec" bsp module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+#include <nrf.h>
+#include <nrf_peripherals.h>
+#include <assert.h>
+#include <stdint.h>
+#include "gpio.h"
+#include "qdec.h"
+
+//=========================== defines ==========================================
+
+typedef struct {
+    qdec_cb_t callback;
+    void     *ctx;
+} qdec_vars_t;
+
+//=========================== variables ========================================
+
+static qdec_vars_t    _qdec_vars[QDEC_COUNT];
+static NRF_QDEC_Type *_qdec_devs[QDEC_COUNT] = {
+    NRF_QDEC0_S,
+    NRF_QDEC1_S
+};
+
+//=========================== public ===========================================
+
+void db_qdec_init(qdec_t qdec, const qdec_conf_t *conf, qdec_cb_t callback, void *ctx) {
+    assert((qdec < QDEC_COUNT));
+
+    // Disable before configuration
+    _qdec_devs[qdec]->ENABLE = (QDEC_ENABLE_ENABLE_Disabled << QDEC_ENABLE_ENABLE_Pos);
+
+    // Setup gpios
+    db_gpio_init(conf->pin_a, DB_GPIO_IN_PU);
+    db_gpio_init(conf->pin_b, DB_GPIO_IN_PU);
+
+    _qdec_devs[qdec]->PSEL.A   = (conf->pin_a->port << QDEC_PSEL_A_PORT_Pos) | (conf->pin_a->pin << QDEC_PSEL_A_PIN_Pos) | (QDEC_PSEL_A_CONNECT_Connected << QDEC_PSEL_A_CONNECT_Pos);
+    _qdec_devs[qdec]->PSEL.B   = (conf->pin_b->port << QDEC_PSEL_B_PORT_Pos) | (conf->pin_b->pin << QDEC_PSEL_B_PIN_Pos) | (QDEC_PSEL_B_CONNECT_Connected << QDEC_PSEL_B_CONNECT_Pos);
+    _qdec_devs[qdec]->PSEL.LED = (QDEC_PSEL_B_CONNECT_Disconnected << QDEC_PSEL_B_CONNECT_Pos);
+
+    // Configure callback and interrupt
+    _qdec_vars[qdec].callback = callback;
+    _qdec_vars[qdec].ctx      = ctx;
+
+    if (callback) {
+        // The driver is only interested in the accumulator overflow event
+        _qdec_devs[qdec]->INTENSET |= (QDEC_INTENSET_ACCOF_Enabled << QDEC_INTENSET_ACCOF_Pos);
+        NVIC_ClearPendingIRQ(QDEC0_IRQn + qdec);
+        NVIC_EnableIRQ(QDEC0_IRQn + qdec);
+    }
+
+    // Enable debounce filter
+    _qdec_devs[qdec]->DBFEN = QDEC_DBFEN_DBFEN_Enabled << QDEC_DBFEN_DBFEN_Pos;
+
+    // Enable and start peripheral
+    _qdec_devs[qdec]->ENABLE = (QDEC_ENABLE_ENABLE_Enabled << QDEC_ENABLE_ENABLE_Pos);
+
+    // Start
+    _qdec_devs[qdec]->TASKS_START = (QDEC_TASKS_START_TASKS_START_Trigger << QDEC_TASKS_START_TASKS_START_Pos);
+}
+
+int16_t db_qdec_read(qdec_t qdec) {
+    return (int16_t)_qdec_devs[qdec]->ACC;
+}
+
+int16_t db_qdec_read_and_clear(qdec_t qdec) {
+    _qdec_devs[qdec]->TASKS_RDCLRACC = 1;
+    return (int16_t)_qdec_devs[qdec]->ACCREAD;
+}
+
+static void qdec_isr(qdec_t qdec) {
+    _qdec_devs[qdec]->EVENTS_ACCOF = 0;
+    _qdec_vars[qdec].callback(_qdec_vars[qdec].ctx);
+};
+
+void QDEC0_IRQHandler(void) {
+    qdec_isr(0);
+}
+
+void QDEC1_IRQHandler(void) {
+    qdec_isr(1);
+}

--- a/bsp/qdec.h
+++ b/bsp/qdec.h
@@ -1,0 +1,55 @@
+#ifndef __QDEC_H
+#define __QDEC_H
+
+/**
+ * @file qdec.h
+ * @addtogroup BSP
+ *
+ * @brief  Cross-platform declaration "qdec" bsp module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include <nrf.h>
+#include <stdint.h>
+#include "gpio.h"
+
+//=========================== defines ==========================================
+
+typedef void (*qdec_cb_t)(void *ctx);  ///< Callback function prototype, it is called on each qdec interrupt
+
+typedef uint8_t qdec_t;
+
+typedef struct {
+    const gpio_t *pin_a;  ///< GPIO pin A
+    const gpio_t *pin_b;  ///< GPIO pin B
+} qdec_conf_t;
+
+//============================ public ==========================================
+
+/**
+ * @brief   Initialize a QDEC
+ *
+ * @param[in]   qdec            Pointer to the qdec descriptor
+ * @param[in]   callback        Function pointer that is called from QDEC ISR
+ * @param[in]   ctx             Pointer to some context passed as parameter to the callback
+ */
+void db_qdec_init(qdec_t qdec, const qdec_conf_t *conf, qdec_cb_t callback, void *ctx);
+
+/**
+ * @brief   Read the QDEC accumulator
+ *
+ * @param[in]   qdec            Index of the QDEC peripheral to read
+ */
+int16_t db_qdec_read(qdec_t qdec);
+
+/**
+ * @brief   Read and clear the QDEC accumulator
+ *
+ * @param[in]   qdec            Index of the QDEC peripheral to read and reset
+ */
+int16_t db_qdec_read_and_clear(qdec_t qdec);
+
+#endif

--- a/projects/01bsp_qdec/01bsp_qdec.c
+++ b/projects/01bsp_qdec/01bsp_qdec.c
@@ -1,0 +1,74 @@
+/**
+ * @file 01bsp_qdec.c
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @brief This is a short example of how to use the QDEC api.
+ *
+ * @copyright Inria, 2023
+ *
+ */
+#include <nrf.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "board_config.h"
+#include "gpio.h"
+#include "qdec.h"
+#include "timer.h"
+
+//=========================== defines ==========================================
+
+#define QDEC_LEFT  0
+#define QDEC_RIGHT 1
+
+typedef struct {
+    bool left_overflow;
+    bool right_overflow;
+} qdec_vars_t;
+
+//=========================== variables ========================================
+
+static const qdec_conf_t qdec_left = {
+    .pin_a = &db_qdec_left_a_pin,
+    .pin_b = &db_qdec_left_b_pin,
+};
+
+static const qdec_conf_t qdec_right = {
+    .pin_a = &db_qdec_right_a_pin,
+    .pin_b = &db_qdec_right_b_pin,
+};
+
+static qdec_vars_t _qdec_vars = {
+    .left_overflow  = false,
+    .right_overflow = false,
+};
+
+//=========================== callbacks ========================================
+
+static void _callback(void *ctx) {
+    *(bool *)ctx = true;
+}
+
+//=========================== main =============================================
+
+int main(void) {
+    db_qdec_init(QDEC_LEFT, &qdec_left, _callback, (void *)&_qdec_vars.left_overflow);
+    db_qdec_init(QDEC_RIGHT, &qdec_right, _callback, (void *)&_qdec_vars.right_overflow);
+
+    db_timer_init();
+
+    while (1) {
+        if (!_qdec_vars.left_overflow) {
+            printf("ACC left: %i\n", db_qdec_read(QDEC_LEFT));
+        } else {
+            printf("ACC left (overflow): %i\n", db_qdec_read_and_clear(QDEC_LEFT));
+            _qdec_vars.left_overflow = false;
+        }
+        if (!_qdec_vars.right_overflow) {
+            printf("ACC right: %i\n", db_qdec_read(QDEC_RIGHT));
+        } else {
+            printf("ACC right (overflow): %i\n", db_qdec_read_and_clear(QDEC_RIGHT));
+            _qdec_vars.right_overflow = false;
+        }
+        db_timer_delay_s(1);
+    }
+}

--- a/projects/01bsp_qdec/README.md
+++ b/projects/01bsp_qdec/README.md
@@ -1,0 +1,2 @@
+# QDEC board support package usage example
+

--- a/projects/projects-bsp-drv.emProject
+++ b/projects/projects-bsp-drv.emProject
@@ -195,6 +195,45 @@
       <file file_name="$(SeggerThumbStartup)" />
     </folder>
   </project>
+  <project Name="01bsp_qdec">
+    <configuration
+      Name="Common"
+      project_dependencies="00bsp_qdec(bsp);00bsp_timer(bsp)"
+      project_directory="01bsp_qdec"
+      project_type="Executable" />
+    <folder Name="Device Files">
+      <file file_name="$(DeviceCommonHeaderFile)" />
+      <file file_name="$(DeviceHeaderFile)" />
+      <file file_name="$(DeviceSystemFile)">
+        <configuration
+          Name="Common"
+          default_code_section=".init"
+          default_const_section=".init_rodata" />
+      </file>
+    </folder>
+    <folder Name="Script Files">
+      <file file_name="$(DeviceLinkerScript)">
+        <configuration Name="Common" file_type="Linker Script" />
+      </file>
+      <file file_name="$(DeviceMemoryMap)">
+        <configuration Name="Common" file_type="Memory Map" />
+      </file>
+      <file file_name="../../nRF/Scripts/nRF_Target.js">
+        <configuration Name="Common" file_type="Reset Script" />
+      </file>
+    </folder>
+    <folder Name="Source Files">
+      <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;asm;inc" />
+      <file file_name="01bsp_qdec.c" />
+    </folder>
+    <folder Name="System Files">
+      <file file_name="$(DeviceCommonVectorsFile)" />
+      <file file_name="$(DeviceVectorsFile)">
+        <configuration Name="Common" file_type="Assembly" />
+      </file>
+      <file file_name="$(SeggerThumbStartup)" />
+    </folder>
+  </project>
   <project Name="01bsp_radio_lr_txrx">
     <configuration
       Name="Common"


### PR DESCRIPTION
This is a first attempt to add low-level support for qdec. Support only works with nrf5340 because it provides 2 peripherals (one for each motors for example). nrf52 only have one.

fixes #210
based on #206 