### PR TITLE
drv: add library to support rgbled via 3 pwm pins

### DIFF
--- a/bsp/conf/dotbot_v2_config.h
+++ b/bsp/conf/dotbot_v2_config.h
@@ -136,4 +136,16 @@
 #define DB_LIS2MDL_INT_PIN  DB_DEBUG3_PIN
 /** @} */
 
+/**
+ * @name    RGB LED pwm pins definitions
+ * @{
+ */
+#define DB_RGB_LED_PWM_RED_PORT   1
+#define DB_RGB_LED_PWM_RED_PIN    7
+#define DB_RGB_LED_PWM_GREEN_PORT 0
+#define DB_RGB_LED_PWM_GREEN_PIN  10
+#define DB_RGB_LED_PWM_BLUE_PORT  1
+#define DB_RGB_LED_PWM_BLUE_PIN   6
+/** @} */
+
 #endif

--- a/bsp/conf/nrf52833dk_config.h
+++ b/bsp/conf/nrf52833dk_config.h
@@ -122,4 +122,16 @@
 #define DB_LIS2MDL_INT_PIN  DB_DEBUG3_PIN
 /** @} */
 
+/**
+ * @name    RGB LED pwm pins definitions
+ * @{
+ */
+#define DB_RGB_LED_PWM_RED_PORT   DB_DEBUG1_PORT
+#define DB_RGB_LED_PWM_RED_PIN    DB_DEBUG1_PIN
+#define DB_RGB_LED_PWM_GREEN_PORT DB_DEBUG2_PORT
+#define DB_RGB_LED_PWM_GREEN_PIN  DB_DEBUG2_PIN
+#define DB_RGB_LED_PWM_BLUE_PORT  DB_DEBUG3_PORT
+#define DB_RGB_LED_PWM_BLUE_PIN   DB_DEBUG3_PIN
+/** @} */
+
 #endif

--- a/bsp/conf/nrf52840dk_config.h
+++ b/bsp/conf/nrf52840dk_config.h
@@ -122,4 +122,16 @@
 #define DB_LIS2MDL_INT_PIN  DB_DEBUG3_PIN
 /** @} */
 
+/**
+ * @name    RGB LED pwm pins definitions
+ * @{
+ */
+#define DB_RGB_LED_PWM_RED_PORT   DB_DEBUG1_PORT
+#define DB_RGB_LED_PWM_RED_PIN    DB_DEBUG1_PIN
+#define DB_RGB_LED_PWM_GREEN_PORT DB_DEBUG2_PORT
+#define DB_RGB_LED_PWM_GREEN_PIN  DB_DEBUG2_PIN
+#define DB_RGB_LED_PWM_BLUE_PORT  DB_DEBUG3_PORT
+#define DB_RGB_LED_PWM_BLUE_PIN   DB_DEBUG3_PIN
+/** @} */
+
 #endif

--- a/bsp/conf/nrf5340dk_config.h
+++ b/bsp/conf/nrf5340dk_config.h
@@ -136,4 +136,16 @@
 #define DB_LIS2MDL_INT_PIN  DB_DEBUG3_PIN
 /** @} */
 
+/**
+ * @name    RGB LED pwm pins definitions
+ * @{
+ */
+#define DB_RGB_LED_PWM_RED_PORT   DB_DEBUG1_PORT
+#define DB_RGB_LED_PWM_RED_PIN    DB_DEBUG1_PIN
+#define DB_RGB_LED_PWM_GREEN_PORT DB_DEBUG2_PORT
+#define DB_RGB_LED_PWM_GREEN_PIN  DB_DEBUG2_PIN
+#define DB_RGB_LED_PWM_BLUE_PORT  DB_DEBUG3_PORT
+#define DB_RGB_LED_PWM_BLUE_PIN   DB_DEBUG3_PIN
+/** @} */
+
 #endif

--- a/bsp/nrf/motors.c
+++ b/bsp/nrf/motors.c
@@ -27,7 +27,7 @@
 //=========================== public ==========================================
 
 void db_motors_init(void) {
-    db_pwm_init(db_motors_pins, PWM_CHANNELS, M_TOP);
+    db_pwm_init(0, db_motors_pins, PWM_CHANNELS, M_TOP);
 }
 
 void db_motors_set_speed(int16_t l_speed, int16_t r_speed) {
@@ -74,5 +74,5 @@ void db_motors_set_speed(int16_t l_speed, int16_t r_speed) {
     }
 
     // Update PWM values
-    db_pwm_channels_set(pwm_seq);
+    db_pwm_channels_set(0, pwm_seq);
 }

--- a/bsp/nrf/pwm.c
+++ b/bsp/nrf/pwm.c
@@ -14,17 +14,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <nrf.h>
+#include <nrf_peripherals.h>
 
 #include "gpio.h"
 #include "pwm.h"
 
 //=========================== defines ==========================================
 
-#if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
-#define DB_PWM (NRF_PWM0_S)
-#else
-#define DB_PWM (NRF_PWM0)
-#endif
 #define DB_PWM_MAX_CHANNELS (4)
 
 // Variable that stores the PWM duty cycle for all four PWM channels
@@ -35,43 +31,56 @@ typedef struct {
 
 //=========================== variables ========================================
 
+static NRF_PWM_Type *_pwm_devs[PWM_COUNT] = {
+#if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
+    NRF_PWM0_S,
+    NRF_PWM1_S,
+    NRF_PWM2_S,
+    NRF_PWM3_S,
+#else
+    NRF_PWM0,
+    NRF_PWM1,
+    NRF_PWM2,
+    NRF_PWM3,
+#endif
+};
 static pwm_vars_t pwm_vars;
 
 //=========================== public ===========================================
 
-void db_pwm_init(const gpio_t *pins, size_t num_channels, uint16_t mtop) {
+void db_pwm_init(pwm_t pwm, const gpio_t *pins, size_t num_channels, uint16_t mtop) {
 
     // configure PWM channel pins;
     for (uint8_t channel = 0; channel < num_channels; channel++) {
         // Configure the PWM pins as output.
         db_gpio_init(&pins[channel], DB_GPIO_OUT);
-        DB_PWM->PSEL.OUT[channel] = (pins[channel].port << PWM_PSEL_OUT_PORT_Pos) |
-                                    (pins[channel].pin << PWM_PSEL_OUT_PIN_Pos) |
-                                    (PWM_PSEL_OUT_CONNECT_Connected << PWM_PSEL_OUT_CONNECT_Pos);
+        _pwm_devs[pwm]->PSEL.OUT[channel] = (pins[channel].port << PWM_PSEL_OUT_PORT_Pos) |
+                                            (pins[channel].pin << PWM_PSEL_OUT_PIN_Pos) |
+                                            (PWM_PSEL_OUT_CONNECT_Connected << PWM_PSEL_OUT_CONNECT_Pos);
     }
 
     // Enable the PWM peripheral
-    DB_PWM->ENABLE = (PWM_ENABLE_ENABLE_Enabled << PWM_ENABLE_ENABLE_Pos);
+    _pwm_devs[pwm]->ENABLE = (PWM_ENABLE_ENABLE_Enabled << PWM_ENABLE_ENABLE_Pos);
 
     // Configure PWM frequency and counting mode
-    DB_PWM->PRESCALER  = PWM_PRESCALER_PRESCALER_DIV_16;               // 1MHz clock
-    DB_PWM->COUNTERTOP = mtop;                                         // for example 100us period for the PWM signal means 10kHz
-    DB_PWM->MODE       = (PWM_MODE_UPDOWN_Up << PWM_MODE_UPDOWN_Pos);  // UP counting mode
-    DB_PWM->LOOP       = (PWM_LOOP_CNT_Disabled << PWM_LOOP_CNT_Pos);  // Disable single sequence looping feature
+    _pwm_devs[pwm]->PRESCALER  = PWM_PRESCALER_PRESCALER_DIV_16;               // 1MHz clock
+    _pwm_devs[pwm]->COUNTERTOP = mtop;                                         // for example 100us period for the PWM signal means 10kHz
+    _pwm_devs[pwm]->MODE       = (PWM_MODE_UPDOWN_Up << PWM_MODE_UPDOWN_Pos);  // UP counting mode
+    _pwm_devs[pwm]->LOOP       = (PWM_LOOP_CNT_Disabled << PWM_LOOP_CNT_Pos);  // Disable single sequence looping feature
 
     // Configure how many, and how the PWM dutycycles are loaded from memory
-    DB_PWM->DECODER = (PWM_DECODER_LOAD_Individual << PWM_DECODER_LOAD_Pos) |   // Have a different duty cycle value for each channel.
-                      (PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);  // Reload the duty cycle values after every period, no delay
+    _pwm_devs[pwm]->DECODER = (PWM_DECODER_LOAD_Individual << PWM_DECODER_LOAD_Pos) |   // Have a different duty cycle value for each channel.
+                              (PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);  // Reload the duty cycle values after every period, no delay
 
     // Configure the EasyDMA variables for loading the duty cycle values.
-    DB_PWM->SEQ[0].PTR = ((uint32_t)(pwm_vars.seq) << PWM_SEQ_PTR_PTR_Pos);
-    DB_PWM->SEQ[0].CNT = (DB_PWM_MAX_CHANNELS << PWM_SEQ_CNT_CNT_Pos);
+    _pwm_devs[pwm]->SEQ[0].PTR = ((uint32_t)(pwm_vars.seq) << PWM_SEQ_PTR_PTR_Pos);
+    _pwm_devs[pwm]->SEQ[0].CNT = (DB_PWM_MAX_CHANNELS << PWM_SEQ_CNT_CNT_Pos);
 
-    DB_PWM->SEQ[0].REFRESH  = 0UL;
-    DB_PWM->SEQ[0].ENDDELAY = 0UL;
+    _pwm_devs[pwm]->SEQ[0].REFRESH  = 0UL;
+    _pwm_devs[pwm]->SEQ[0].ENDDELAY = 0UL;
 
     // Activate the automatic looping of the PWM duty cycle sequence.
-    DB_PWM->SHORTS = (PWM_SHORTS_LOOPSDONE_SEQSTART0_Enabled << PWM_SHORTS_LOOPSDONE_SEQSTART0_Pos);
+    _pwm_devs[pwm]->SHORTS = (PWM_SHORTS_LOOPSDONE_SEQSTART0_Enabled << PWM_SHORTS_LOOPSDONE_SEQSTART0_Pos);
 
     // For safety, initialize all PWMs to zero.
     for (uint8_t channel = 0; channel < DB_PWM_MAX_CHANNELS; channel++) {
@@ -81,20 +90,20 @@ void db_pwm_init(const gpio_t *pins, size_t num_channels, uint16_t mtop) {
     }
 }
 
-void db_pwm_channel_set(uint8_t channel, uint16_t value) {
+void db_pwm_channel_set(pwm_t pwm, uint8_t channel, uint16_t value) {
     assert(channel < DB_PWM_MAX_CHANNELS);
 
     pwm_vars.seq[channel] = value | 1 << 15;
     // Update PWM values
-    DB_PWM->TASKS_SEQSTART[0] = PWM_TASKS_SEQSTART_TASKS_SEQSTART_Trigger;
+    _pwm_devs[pwm]->TASKS_SEQSTART[0] = PWM_TASKS_SEQSTART_TASKS_SEQSTART_Trigger;
 }
 
-void db_pwm_channels_set(uint16_t *values) {
+void db_pwm_channels_set(pwm_t pwm, uint16_t *values) {
     assert(sizeof(values) == DB_PWM_MAX_CHANNELS);
 
     for (uint8_t channel = 0; channel < DB_PWM_MAX_CHANNELS; channel++) {
         pwm_vars.seq[channel] = values[channel] | 1 << 15;
     }
     // Update PWM values
-    DB_PWM->TASKS_SEQSTART[0] = PWM_TASKS_SEQSTART_TASKS_SEQSTART_Trigger;
+    _pwm_devs[pwm]->TASKS_SEQSTART[0] = PWM_TASKS_SEQSTART_TASKS_SEQSTART_Trigger;
 }

--- a/bsp/pwm.h
+++ b/bsp/pwm.h
@@ -15,6 +15,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "gpio.h"
+#include "nrf.h"
+
+//=========================== defines ==========================================
+
+typedef uint8_t pwm_t;
 
 //=========================== public ===========================================
 
@@ -27,29 +32,32 @@
  * The number of channels must not exceed the size of the array containing
  * the pins.
  *
+ * @param[in] pwm           index of the PWM peripheral to initialize
  * @param[in] pins          pointer to array of pointer to GPIO pins
  * @param[in] num_channels  number of channels to configure
  * @param[in] mtop          max value of the PWM counter register
  */
-void db_pwm_init(const gpio_t *pins, size_t num_channels, uint16_t mtop);
+void db_pwm_init(pwm_t pwm, const gpio_t *pins, size_t num_channels, uint16_t mtop);
 
 /**
  * @brief Set the value of a PWM channel
  *
  * The channel value must be lower or equal to 3.
  *
+ * @param[in] pwm       index of the PWM peripheral
  * @param[in] channel   index of channel to set
  * @param[in] value     value to set to the channel
  */
-void db_pwm_channel_set(uint8_t channel, uint16_t value);
+void db_pwm_channel_set(pwm_t pwm, uint8_t channel, uint16_t value);
 
 /**
  * @brief Set the values of all PWM channels
  *
  * The array of values must be 4 bytes long exactly.
  *
+ * @param[in] pwm       index of the PWM peripheral
  * @param[in] values    pointer to the array containing the values to set
  */
-void db_pwm_channels_set(uint16_t *values);
+void db_pwm_channels_set(pwm_t pwm, uint16_t *values);
 
 #endif

--- a/drv/drv.emProject
+++ b/drv/drv.emProject
@@ -75,4 +75,13 @@
     <file file_name="pid/pid.c" />
     <file file_name="pid.h" />
   </project>
+  <project Name="00drv_rgbled_pwm">
+    <configuration
+      Name="Common"
+      project_dependencies="00bsp_pwm(bsp)"
+      project_directory="rgbled_pwm"
+      project_type="Library" />
+    <file file_name="rgbled_pwm.c" />
+    <file file_name="../rgbled_pwm.h" />
+  </project>
 </solution>

--- a/drv/rgbled_pwm.h
+++ b/drv/rgbled_pwm.h
@@ -1,0 +1,43 @@
+#ifndef __RGBLED_PWM_H
+#define __RGBLED_PWM_H
+
+/**
+ * @file rgbled_pwm.h
+ * @addtogroup DRV
+ *
+ * @brief  Cross-platform declaration "rgbled pwm" driver module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "gpio.h"
+#include "pwm.h"
+
+//=========================== definitions ======================================
+
+typedef struct {
+    const gpio_t pins[3];  // red: 0, green: 1, blue: 2
+} db_rgbled_pwm_conf_t;
+
+//=========================== public ===========================================
+
+/**
+ * @brief   Initialize the RGB LED pins
+ *
+ * @param[in]   conf    Configuration for the RGB LED pins
+ */
+void db_rgbled_pwm_init(const db_rgbled_pwm_conf_t *conf);
+
+/**
+ * @brief   Set the color of the RGB LED
+ *
+ * @param[output]   payload     Decoded payload contained in the input buffer
+ */
+void db_rgbled_pwm_set_color(uint8_t red, uint8_t green, uint8_t blue);
+
+#endif

--- a/drv/rgbled_pwm/rgbled_pwm.c
+++ b/drv/rgbled_pwm/rgbled_pwm.c
@@ -1,0 +1,33 @@
+/**
+ * @file rgbled_pwm.c
+ * @addtogroup DRV
+ *
+ * @brief  Implementation of the "rgbled pwm" driver module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "rgbled_pwm.h"
+#include "pwm.h"
+
+//=========================== definitions ======================================
+
+#define PWM_CHANNELS  (3)
+#define PWM_MAX_VALUE (UINT8_MAX)
+
+//=========================== public ===========================================
+
+void db_rgbled_pwm_init(const db_rgbled_pwm_conf_t *conf) {
+    db_pwm_init(1, conf->pins, PWM_CHANNELS, PWM_MAX_VALUE);
+}
+
+void db_rgbled_pwm_set_color(uint8_t red, uint8_t green, uint8_t blue) {
+    uint16_t pwm_seq[PWM_CHANNELS] = { red, green, blue };
+    db_pwm_channels_set(1, pwm_seq);
+}

--- a/projects/01drv_rgbled_pwm/01drv_rgbled_pwm.c
+++ b/projects/01drv_rgbled_pwm/01drv_rgbled_pwm.c
@@ -1,0 +1,59 @@
+/**
+ * @file 01bsp_rgbled_pwm.c
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @brief This is a short example of how to interface with the RGB LED in the DotBot shield.
+ *
+ * Load this program on your board. The LEDs should start blinking different colors.
+ *
+ * @copyright Inria, 2023
+ *
+ */
+#include <nrf.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "board.h"
+#include "rgbled_pwm.h"
+#include "timer.h"
+#include "board_config.h"
+
+//=========================== variables ========================================
+
+#ifdef DB_RGB_LED_PWM_RED_PORT
+static const db_rgbled_pwm_conf_t rgbled_pwm_conf = {
+    .pins = {
+        { .port = DB_RGB_LED_PWM_RED_PORT, .pin = DB_RGB_LED_PWM_RED_PIN },
+        { .port = DB_RGB_LED_PWM_GREEN_PORT, .pin = DB_RGB_LED_PWM_GREEN_PIN },
+        { .port = DB_RGB_LED_PWM_BLUE_PORT, .pin = DB_RGB_LED_PWM_BLUE_PIN },
+    }
+};
+#endif
+
+//=========================== main =============================================
+
+int main(void) {
+    db_board_init();
+    db_timer_init();
+#ifdef DB_RGB_LED_PWM_RED_PORT
+    db_rgbled_pwm_init(&rgbled_pwm_conf);
+#endif
+
+    /* Change RGB colors in a loop */
+    while (1) {
+#ifdef DB_RGB_LED_PWM_RED_PORT
+        db_rgbled_pwm_set_color(255, 0, 0);
+        db_timer_delay_s(2);
+        db_rgbled_pwm_set_color(0, 255, 0);
+        db_timer_delay_s(2);
+        db_rgbled_pwm_set_color(0, 0, 255);
+        db_timer_delay_s(2);
+        db_rgbled_pwm_set_color(255, 255, 0);
+        db_timer_delay_s(2);
+        db_rgbled_pwm_set_color(0, 255, 255);
+        db_timer_delay_s(2);
+        db_rgbled_pwm_set_color(255, 0, 255);
+#else
+        puts("RGB LED pwm not supported!");
+#endif
+        db_timer_delay_s(2);
+    }
+}

--- a/projects/01drv_rgbled_pwm/README.md
+++ b/projects/01drv_rgbled_pwm/README.md
@@ -1,0 +1,4 @@
+# RGB LED board support package usage example
+
+Loading this app onto the DotBot board will change the RGB LED color every 2
+seconds in a loop.

--- a/projects/03app_sailbot/servos.c
+++ b/projects/03app_sailbot/servos.c
@@ -46,7 +46,7 @@ uint16_t calculate_pwm_length(int8_t angle, uint16_t upper_bound, uint16_t lower
  *  @brief Initialization routine of the PWM module.
  */
 void servos_init(void) {
-    db_pwm_init(_pwm_pins, PWM_CHANNELS, M_TOP);
+    db_pwm_init(0, _pwm_pins, PWM_CHANNELS, M_TOP);
 }
 
 void servos_set(int8_t rudder_angle, int8_t sail_angle) {
@@ -56,15 +56,15 @@ void servos_set(int8_t rudder_angle, int8_t sail_angle) {
     pwm[SERVO_RUDDER] = calculate_pwm_length(rudder_angle, RUDDER_POSITION_UPPER_BOUND, RUDDER_POSITION_LOWER_BOUND);
     pwm[SERVO_SAILS]  = calculate_pwm_length(sail_angle, SAIL_POSITION_UPPER_BOUND, SAIL_POSITION_LOWER_BOUND);
 
-    db_pwm_channels_set(pwm);
+    db_pwm_channels_set(0, pwm);
 }
 
 void servos_rudder_turn(int8_t angle) {
-    db_pwm_channel_set((uint8_t)SERVO_RUDDER, calculate_pwm_length(angle, RUDDER_POSITION_UPPER_BOUND, RUDDER_POSITION_LOWER_BOUND));
+    db_pwm_channel_set(0, (uint8_t)SERVO_RUDDER, calculate_pwm_length(angle, RUDDER_POSITION_UPPER_BOUND, RUDDER_POSITION_LOWER_BOUND));
 }
 
 void servos_sail_turn(int8_t angle) {
-    db_pwm_channel_set((uint8_t)SERVO_SAILS, calculate_pwm_length(angle, SAIL_POSITION_UPPER_BOUND, SAIL_POSITION_LOWER_BOUND));
+    db_pwm_channel_set(0, (uint8_t)SERVO_SAILS, calculate_pwm_length(angle, SAIL_POSITION_UPPER_BOUND, SAIL_POSITION_LOWER_BOUND));
 }
 
 //=========================== private =========================================

--- a/projects/projects-bsp-drv.emProject
+++ b/projects/projects-bsp-drv.emProject
@@ -744,4 +744,43 @@
       <file file_name="$(SeggerThumbStartup)" />
     </folder>
   </project>
+  <project Name="01drv_rgbled_pwm">
+    <configuration
+      Name="Common"
+      project_dependencies="00bsp_dotbot_board(bsp);00bsp_timer(bsp);00drv_rgbled_pwm(drv)"
+      project_directory="01drv_rgbled_pwm"
+      project_type="Executable" />
+    <folder Name="Device Files">
+      <file file_name="$(DeviceCommonHeaderFile)" />
+      <file file_name="$(DeviceHeaderFile)" />
+      <file file_name="$(DeviceSystemFile)">
+        <configuration
+          Name="Common"
+          default_code_section=".init"
+          default_const_section=".init_rodata" />
+      </file>
+    </folder>
+    <folder Name="Script Files">
+      <file file_name="$(DeviceLinkerScript)">
+        <configuration Name="Common" file_type="Linker Script" />
+      </file>
+      <file file_name="$(DeviceMemoryMap)">
+        <configuration Name="Common" file_type="Memory Map" />
+      </file>
+      <file file_name="../../nRF/Scripts/nRF_Target.js">
+        <configuration Name="Common" file_type="Reset Script" />
+      </file>
+    </folder>
+    <folder Name="Source Files">
+      <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;asm;inc" />
+      <file file_name="01drv_rgbled_pwm.c" />
+    </folder>
+    <folder Name="System Files">
+      <file file_name="$(DeviceCommonVectorsFile)" />
+      <file file_name="$(DeviceVectorsFile)">
+        <configuration Name="Common" file_type="Assembly" />
+      </file>
+      <file file_name="$(SeggerThumbStartup)" />
+    </folder>
+  </project>
 </solution>


### PR DESCRIPTION
The PWM API had to be refactored to support multiple PWM peripherals (because they are also used for controlling the DotBot motors for example).

fixes #211
based on #206 