### PR TITLE
drv: add move library for dotbot (using qdec)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ifeq (nrf5340dk-app,$(BUILD_TARGET))
     01bsp_timer_hf \
     01bsp_uart \
     01drv_lis2mdl \
+    01drv_move \
     01drv_pid \
     03app_dotbot \
     03app_dotbot_gateway \
@@ -58,7 +59,7 @@ endif
 
 # remove incompatible apps (nrf5340, sailbot gateway) for dotbot (v1, v2) builds
 ifneq (,$(filter dotbot-v1,$(BUILD_TARGET)))
-  PROJECTS := $(filter-out 01bsp_qdec 03app_dotbot_gateway 03app_sailbot 03app_nrf5340_%,$(PROJECTS))
+  PROJECTS := $(filter-out 01bsp_qdec 01drv_move 03app_dotbot_gateway 03app_sailbot 03app_nrf5340_%,$(PROJECTS))
   ARTIFACT_PROJECTS := 03app_dotbot
 endif
 
@@ -69,13 +70,13 @@ endif
 
 # remove incompatible apps (nrf5340, dotbot, gateway) for sailbot-v1 build
 ifeq (sailbot-v1,$(BUILD_TARGET))
-  PROJECTS := $(filter-out 01bsp_qdec 03app_dotbot_gateway 03app_dotbot 03app_nrf5340_%,$(PROJECTS))
+  PROJECTS := $(filter-out 01bsp_qdec 01drv_move 03app_dotbot_gateway 03app_dotbot 03app_nrf5340_%,$(PROJECTS))
   ARTIFACT_PROJECTS := 03app_sailbot
 endif
 
 # remove incompatible apps (nrf5340) for nrf52833dk/nrf52840dk build
 ifneq (,$(filter nrf52833dk nrf52840dk,$(BUILD_TARGET)))
-  PROJECTS := $(filter-out 01bsp_qdec 03app_nrf5340_%,$(PROJECTS))
+  PROJECTS := $(filter-out 01bsp_qdec 01drv_move 03app_nrf5340_%,$(PROJECTS))
   ARTIFACT_PROJECTS ?= 03app_dotbot_gateway
 endif
 

--- a/drv/drv.emProject
+++ b/drv/drv.emProject
@@ -67,6 +67,15 @@
     <file file_name="log_flash/log_flash.c" />
     <file file_name="log_flash.h" />
   </project>
+  <project Name="00drv_move">
+    <configuration
+      Name="Common"
+      project_dependencies="00bsp_dotbot_board(bsp);00bsp_dotbot_motors(bsp);00bsp_qdec(bsp);00bsp_timer(bsp)"
+      project_directory="."
+      project_type="Library" />
+    <file file_name="move/move.c" />
+    <file file_name="move.h" />
+  </project>
   <project Name="00drv_pid">
     <configuration
       Name="Common"

--- a/drv/move.h
+++ b/drv/move.h
@@ -1,0 +1,40 @@
+#ifndef __MOVE_H
+#define __MOVE_H
+
+/**
+ * @file move.h
+ * @addtogroup DRV
+ *
+ * @brief  Cross-platform declaration "move" driver module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include <stdint.h>
+
+//=========================== public ===========================================
+
+/**
+ * @brief   Initialize qdec and motors
+ */
+void db_move_init();
+
+/**
+ * @brief   Move straight by a given distance at a given speed
+ *
+ * @param[in]   distance        Distance in centimeters
+ * @param[in]   speed           Move speed, -100 to 100
+ */
+void db_move_straight(uint16_t distance, int8_t speed);
+
+/**
+ * @brief   Rotate by a given angle at a given speed
+ *
+ * @param[in]   angle           Angle of clockwise rotation in degrees
+ * @param[in]   speed           Rotation speed, -100 to 100
+ */
+void db_move_rotate(uint16_t angle, int8_t speed);
+
+#endif

--- a/drv/move/move.c
+++ b/drv/move/move.c
@@ -1,0 +1,105 @@
+/**
+ * @file move.c
+ * @addtogroup DRV
+ *
+ * @brief  Implemenation of the "move" driver module.
+ *
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <math.h>
+#include "board.h"
+#include "board_config.h"
+#include "motors.h"
+#include "qdec.h"
+#include "timer.h"
+
+#include "move.h"
+
+//=========================== define ===========================================
+
+#define REFRESH_DELAY_MS       (10)  //< ms
+#define DOTBOT_MOTOR_REDUCTION (50)  //< Motor reduction factor
+#define DOTBOT_ENCODER_CPR     (12)  //< Encoder count per rotation
+#define DOTBOT_WHEEL_RADIUS    (20)  //< mm
+#define DOTBOT_RADIUS          (45)  //< mm
+#define QDEC_LEFT              (0)
+
+//=========================== variables ========================================
+
+static const qdec_conf_t qdec_left = {
+    .pin_a = &db_qdec_left_a_pin,
+    .pin_b = &db_qdec_left_b_pin,
+};
+
+//=========================== private ==========================================
+
+static float _distance_from_accumulator(int16_t accumulator) {
+    return (((float)accumulator / DOTBOT_ENCODER_CPR) * 2 * M_PI * DOTBOT_WHEEL_RADIUS) / DOTBOT_MOTOR_REDUCTION;
+}
+
+static float _angle_from_accumulator(int16_t accumulator) {
+    return (180 * _distance_from_accumulator(accumulator)) / (M_PI * DOTBOT_RADIUS);
+}
+
+static void _move_reset(void) {
+    db_qdec_read_and_clear(QDEC_LEFT);
+}
+
+//=========================== public ===========================================
+
+void db_move_init(void) {
+    db_board_init();
+    db_motors_init();
+
+    db_timer_init();
+
+    db_qdec_init(QDEC_LEFT, &qdec_left, NULL, NULL);
+}
+
+void db_move_straight(uint16_t distance, int8_t speed) {
+    _move_reset();
+
+    if (distance == 0) {
+        return;
+    }
+
+    int32_t accumulator = 0;
+    db_motors_set_speed(speed, speed);
+    while (1) {
+        accumulator += db_qdec_read_and_clear(QDEC_LEFT);
+        float current_distance = fabs(_distance_from_accumulator(accumulator));
+        if ((current_distance > (float)distance)) {
+            break;
+        }
+        db_timer_delay_ms(REFRESH_DELAY_MS);
+    }
+
+    db_motors_set_speed(0, 0);
+}
+
+void db_move_rotate(uint16_t angle, int8_t speed) {
+    _move_reset();
+    if (angle == 0) {
+        return;
+    }
+
+    int32_t accumulator = 0;
+    db_motors_set_speed(speed, speed * -1);
+    while (1) {
+        accumulator += db_qdec_read_and_clear(QDEC_LEFT);
+        float current_angle = fabs(_angle_from_accumulator(accumulator));
+        if ((current_angle > (float)angle)) {
+            break;
+        }
+
+        db_timer_delay_ms(REFRESH_DELAY_MS);
+    }
+
+    db_motors_set_speed(0, 0);
+}

--- a/projects/01drv_move/01drv_move.c
+++ b/projects/01drv_move/01drv_move.c
@@ -1,0 +1,30 @@
+/**
+ * @file 01drv_move.c
+ * @author Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @copyright Inria, 2023
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <nrf.h>
+#include "move.h"
+
+//=========================== main =============================================
+
+int main(void) {
+
+    db_move_init();
+    db_move_straight(200, 60);
+    db_move_rotate(90, 60);
+    db_move_straight(200, 60);
+    db_move_rotate(90, 60);
+    db_move_straight(200, 60);
+    db_move_rotate(90, 60);
+    db_move_straight(200, 60);
+
+    while (1) {
+        __WFE();
+    }
+}

--- a/projects/01drv_move/README.md
+++ b/projects/01drv_move/README.md
@@ -1,0 +1,1 @@
+# High-level move controls for the DotBot

--- a/projects/projects-bsp-drv.emProject
+++ b/projects/projects-bsp-drv.emProject
@@ -705,6 +705,45 @@
       <file file_name="$(SeggerThumbStartup)" />
     </folder>
   </project>
+  <project Name="01drv_move">
+    <configuration
+      Name="Common"
+      project_dependencies="00bsp_timer(bsp);00drv_move(drv)"
+      project_directory="01drv_move"
+      project_type="Executable" />
+    <folder Name="Device Files">
+      <file file_name="$(DeviceCommonHeaderFile)" />
+      <file file_name="$(DeviceHeaderFile)" />
+      <file file_name="$(DeviceSystemFile)">
+        <configuration
+          Name="Common"
+          default_code_section=".init"
+          default_const_section=".init_rodata" />
+      </file>
+    </folder>
+    <folder Name="Script Files">
+      <file file_name="$(DeviceLinkerScript)">
+        <configuration Name="Common" file_type="Linker Script" />
+      </file>
+      <file file_name="$(DeviceMemoryMap)">
+        <configuration Name="Common" file_type="Memory Map" />
+      </file>
+      <file file_name="../../nRF/Scripts/nRF_Target.js">
+        <configuration Name="Common" file_type="Reset Script" />
+      </file>
+    </folder>
+    <folder Name="Source Files">
+      <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;asm;inc" />
+      <file file_name="01drv_move.c" />
+    </folder>
+    <folder Name="System Files">
+      <file file_name="$(DeviceCommonVectorsFile)" />
+      <file file_name="$(DeviceVectorsFile)">
+        <configuration Name="Common" file_type="Assembly" />
+      </file>
+      <file file_name="$(SeggerThumbStartup)" />
+    </folder>
+  </project>
   <project Name="01drv_pid">
     <configuration
       Name="Common"


### PR DESCRIPTION
This PR adds an high level driver library to move a DotBot. The library contains 2 functions:
- to move the dotbot on a straight line given a distance in mm and a speed (negative speed means move backwards)
- to rotate the dotbot with a given angle and a speed

The library is quite basic for the moment: only the left quadratic decoder is used so there's no real-time correction of the motors (pid style).

It can be pretty useful with the control loop to rotate the dotbot prior to move it forward.