### PR TITLE
.readthedoc.yaml: add initial configuration

### DIFF
--- a/.readthedoc.yaml
+++ b/.readthedoc.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: doc/sphinx/source/conf.py
+
+python:
+  install:
+  - requirements: docs/sphinx/requirements.txt


### PR DESCRIPTION
Let's rather publish the documentation there.

fixes #239 