### PR TITLE
SailBot: Wind Sensor Integration and Bug Fixes

### DIFF
--- a/drv/as5048b/as5048b.c
+++ b/drv/as5048b/as5048b.c
@@ -20,7 +20,7 @@
 
 //=========================== defines ==========================================
 // Define scl and sda gpio pins
-// db_scl and db_sda are defined in board_config.h 
+// db_scl and db_sda are defined in board_config.h
 // For SailBot PCB: sda=TP3, scl=TP4
 
 // Hardware settings of pins A1 and A2 define the last two bits of the slave address

--- a/drv/as5048b/as5048b.c
+++ b/drv/as5048b/as5048b.c
@@ -13,14 +13,15 @@
 #include <math.h>
 
 // Include BSP packages
+#include "board_config.h"
 #include "gpio.h"
 #include "i2c.h"
 #include "as5048b.h"
 
 //=========================== defines ==========================================
 // Define scl and sda gpio pins
-static const gpio_t sda_encoder = { .port = 0, .pin = 9 };
-static const gpio_t scl_encoder = { .port = 0, .pin = 10 };
+// db_scl and db_sda are defined in board_config.h 
+// For SailBot PCB: sda=TP3, scl=TP4
 
 // Hardware settings of pins A1 and A2 define the last two bits of the slave address
 // Set A1 and A2 to GND to get default address 0x40
@@ -37,7 +38,7 @@ static const gpio_t scl_encoder = { .port = 0, .pin = 10 };
 // Initialise I2C communication with rotary encoder
 void as5048b_init(void) {
     // AS5048B doesn't have a WHO_AM_I register
-    db_i2c_init(&scl_encoder, &sda_encoder);
+    db_i2c_init(&db_scl, &db_sda);
 }
 
 // Reads two 8-bit registers where the 14-bit raw absolute angle is stored

--- a/drv/as5048b/as5048b.c
+++ b/drv/as5048b/as5048b.c
@@ -37,7 +37,7 @@ static const gpio_t scl_encoder = { .port = 0, .pin = 10 };
 // Initialise I2C communication with rotary encoder
 void as5048b_init(void) {
     // AS5048B doesn't have a WHO_AM_I register
-    db_i2c_init(&sda_encoder, &scl_encoder);
+    db_i2c_init(&scl_encoder, &sda_encoder);
 }
 
 // Reads two 8-bit registers where the 14-bit raw absolute angle is stored

--- a/drv/as5048b/as5048b.c
+++ b/drv/as5048b/as5048b.c
@@ -13,12 +13,14 @@
 #include <math.h>
 
 // Include BSP packages
-#include "board_config.h"
 #include "gpio.h"
 #include "i2c.h"
 #include "as5048b.h"
 
 //=========================== defines ==========================================
+// Define scl and sda gpio pins
+static const gpio_t sda_encoder = { .port = 0, .pin = 9 };
+static const gpio_t scl_encoder = { .port = 0, .pin = 10 };
 
 // Hardware settings of pins A1 and A2 define the last two bits of the slave address
 // Set A1 and A2 to GND to get default address 0x40
@@ -35,7 +37,7 @@
 // Initialise I2C communication with rotary encoder
 void as5048b_init(void) {
     // AS5048B doesn't have a WHO_AM_I register
-    db_i2c_init(&db_scl, &db_sda);
+    db_i2c_init(&sda_encoder, &scl_encoder);
 }
 
 // Reads two 8-bit registers where the 14-bit raw absolute angle is stored

--- a/projects/03app_sailbot/03app_sailbot.c
+++ b/projects/03app_sailbot/03app_sailbot.c
@@ -17,6 +17,8 @@
 #include <nrf.h>
 #include <stdbool.h>
 #include <string.h>
+#include <math.h>
+#include <assert.h>
 
 // Include BSP packages
 #include "device.h"
@@ -30,8 +32,6 @@
 #include "timer.h"
 #include "timer_hf.h"
 #include "gpio.h"
-#include "assert.h"
-#include "math.h"
 #include "as5048b.h"
 
 //=========================== defines =========================================

--- a/projects/03app_sailbot/03app_sailbot.c
+++ b/projects/03app_sailbot/03app_sailbot.c
@@ -36,26 +36,26 @@
 
 //=========================== defines =========================================
 
-#define CONTROL_LOOP_PERIOD_MS          (1000)  ///< control loop period
-#define WAYPOINT_DISTANCE_THRESHOLD     (10)    ///< in meters
+#define CONTROL_LOOP_PERIOD_MS      (1000)  ///< control loop period
+#define WAYPOINT_DISTANCE_THRESHOLD (10)    ///< in meters
 
-#define SAIL_TRIM_ANGLE_UNIT_STEP       (10)     ///< unit step increase/decrease when trimming the sails
-#define TIMEOUT_CHECK_DELAY_TICKS       (17000)  ///< ~500 ms delay between packet received timeout checks
-#define TIMEOUT_CHECK_DELAY_MS          (200)    ///< 200 ms delay between packet received timeout checks
-#define ADVERTISEMENT_PERIOD_MS         (500)    ///< send an advertisement every 500 ms
-#define DB_BUFFER_MAX_BYTES             (64U)    ///< Max bytes in UART receive buffer
+#define SAIL_TRIM_ANGLE_UNIT_STEP (10)     ///< unit step increase/decrease when trimming the sails
+#define TIMEOUT_CHECK_DELAY_TICKS (17000)  ///< ~500 ms delay between packet received timeout checks
+#define TIMEOUT_CHECK_DELAY_MS    (200)    ///< 200 ms delay between packet received timeout checks
+#define ADVERTISEMENT_PERIOD_MS   (500)    ///< send an advertisement every 500 ms
+#define DB_BUFFER_MAX_BYTES       (64U)    ///< Max bytes in UART receive buffer
 
-#define CONST_EARTH_RADIUS_KM           (6371.0F)               // 6371 km
-#define CONST_COS_PHI_0_INRIA_PARIS     (0.658139837F)          // cos(0.85245092073) where 0.85245092073 represent radians latitude of Inria Paris
-#define CONST_COS_PHI_0_UFF             (0.92114562603F)        // cos(0.3997826147759739) where 0.3997826147759739 represents radians latitude of UFF
-#define CONST_METRO_LIBERTE_LAT         (48.825908013055255F)   // coordinates of Metro Liberte subway station in Paris
-#define CONST_METRO_LIBERTE_LONG        (2.4064333460310094F)   // coordinates of Metro Liberte subway station in Paris
-#define CONST_NOTRE_DAME_DE_PARIS_LAT   (48.85443748F)          // coordinates of Notre Dame de Paris
-#define CONST_NOTRE_DAME_DE_PARIS_LONG  (2.350162268F)          // coordinates of Notre Dame de Paris
-#define CONST_METRO_BERCY_LAT           (48.840280818580354F)   // coordinates of Metro Bercy subway station in Paris
-#define CONST_METRO_BERCY_LONG          (2.379762322245707F)    // coordinates of Metro Bercy subway station in Paris
-#define CONST_ESCOLA_NAVAL_LAT          (-22.913357509339527F)  // coordinates of Escola Naval in Rio
-#define CONST_ESCOLA_NAVAL_LONG         (-43.15753771789026F)   // coordinates of Escola Naval in Rio
+#define CONST_EARTH_RADIUS_KM          (6371.0F)               // 6371 km
+#define CONST_COS_PHI_0_INRIA_PARIS    (0.658139837F)          // cos(0.85245092073) where 0.85245092073 represent radians latitude of Inria Paris
+#define CONST_COS_PHI_0_UFF            (0.92114562603F)        // cos(0.3997826147759739) where 0.3997826147759739 represents radians latitude of UFF
+#define CONST_METRO_LIBERTE_LAT        (48.825908013055255F)   // coordinates of Metro Liberte subway station in Paris
+#define CONST_METRO_LIBERTE_LONG       (2.4064333460310094F)   // coordinates of Metro Liberte subway station in Paris
+#define CONST_NOTRE_DAME_DE_PARIS_LAT  (48.85443748F)          // coordinates of Notre Dame de Paris
+#define CONST_NOTRE_DAME_DE_PARIS_LONG (2.350162268F)          // coordinates of Notre Dame de Paris
+#define CONST_METRO_BERCY_LAT          (48.840280818580354F)   // coordinates of Metro Bercy subway station in Paris
+#define CONST_METRO_BERCY_LONG         (2.379762322245707F)    // coordinates of Metro Bercy subway station in Paris
+#define CONST_ESCOLA_NAVAL_LAT         (-22.913357509339527F)  // coordinates of Escola Naval in Rio
+#define CONST_ESCOLA_NAVAL_LONG        (-43.15753771789026F)   // coordinates of Escola Naval in Rio
 
 // user-select defines
 // make sure CONST_COS_PHI_0 latitude is approximately at the middle of the map
@@ -320,18 +320,18 @@ static void _send_data(const nmea_gprmc_t *data, uint16_t heading, uint16_t wind
     db_protocol_header_to_buffer(_sailbot_vars.radio_buffer, DB_BROADCAST_ADDRESS, SailBot, DB_PROTOCOL_SAILBOT_DATA);
 
     // define the offsets based on the order of the data
-    size_t header_size      = sizeof(protocol_header_t);
-    size_t heading_size     = sizeof(uint16_t);
-    size_t latitude_size    = sizeof(int32_t);
-    size_t longitude_size   = sizeof(int32_t);
-    size_t wind_angle_size  = sizeof(uint16_t);
+    size_t header_size       = sizeof(protocol_header_t);
+    size_t heading_size      = sizeof(uint16_t);
+    size_t latitude_size     = sizeof(int32_t);
+    size_t longitude_size    = sizeof(int32_t);
+    size_t wind_angle_size   = sizeof(uint16_t);
     size_t rudder_angle_size = sizeof(int8_t);
     size_t sail_trim_size    = sizeof(int8_t);
 
-    size_t heading_offset    = header_size;
-    size_t latitude_offset   = heading_offset + heading_size;
-    size_t longitude_offset  = latitude_offset + latitude_size;
-    size_t wind_angle_offset = longitude_offset + longitude_size;
+    size_t heading_offset      = header_size;
+    size_t latitude_offset     = heading_offset + heading_size;
+    size_t longitude_offset    = latitude_offset + latitude_size;
+    size_t wind_angle_offset   = longitude_offset + longitude_size;
     size_t rudder_angle_offset = wind_angle_offset + rudder_angle_size;
     size_t sail_trim_offset    = rudder_angle_offset + sail_trim_size;
 

--- a/projects/03app_sailbot/03app_sailbot.c
+++ b/projects/03app_sailbot/03app_sailbot.c
@@ -36,26 +36,26 @@
 
 //=========================== defines =========================================
 
-#define CONTROL_LOOP_PERIOD_MS      (1000)  ///< control loop period
-#define WAYPOINT_DISTANCE_THRESHOLD (10)    ///< in meters
+#define CONTROL_LOOP_PERIOD_MS          (1000)  ///< control loop period
+#define WAYPOINT_DISTANCE_THRESHOLD     (10)    ///< in meters
 
-#define SAIL_TRIM_ANGLE_UNIT_STEP (10)     //< unit step increase/decrease when trimming the sails
-#define TIMEOUT_CHECK_DELAY_TICKS (17000)  ///< ~500 ms delay between packet received timeout checks
-#define TIMEOUT_CHECK_DELAY_MS    (200)    ///< 200 ms delay between packet received timeout checks
-#define ADVERTISEMENT_PERIOD_MS   (500)    ///< send an advertisement every 500 ms
-#define DB_BUFFER_MAX_BYTES       (64U)    ///< Max bytes in UART receive buffer
+#define SAIL_TRIM_ANGLE_UNIT_STEP       (10)     ///< unit step increase/decrease when trimming the sails
+#define TIMEOUT_CHECK_DELAY_TICKS       (17000)  ///< ~500 ms delay between packet received timeout checks
+#define TIMEOUT_CHECK_DELAY_MS          (200)    ///< 200 ms delay between packet received timeout checks
+#define ADVERTISEMENT_PERIOD_MS         (500)    ///< send an advertisement every 500 ms
+#define DB_BUFFER_MAX_BYTES             (64U)    ///< Max bytes in UART receive buffer
 
-#define CONST_EARTH_RADIUS_KM          (6371.0F)               // 6371 km
-#define CONST_COS_PHI_0_INRIA_PARIS    (0.658139837F)          // cos(0.85245092073) where 0.85245092073 represent radians latitude of Inria Paris
-#define CONST_COS_PHI_0_UFF            (0.92114562603F)        // cos(0.3997826147759739) where 0.3997826147759739 represents radians latitude of UFF
-#define CONST_METRO_LIBERTE_LAT        (48.825908013055255F)   // coordinates of Metro Liberte subway station in Paris
-#define CONST_METRO_LIBERTE_LONG       (2.4064333460310094F)   // coordinates of Metro Liberte subway station in Paris
-#define CONST_NOTRE_DAME_DE_PARIS_LAT  (48.85443748F)          // coordinates of Notre Dame de Paris
-#define CONST_NOTRE_DAME_DE_PARIS_LONG (2.350162268F)          // coordinates of Notre Dame de Paris
-#define CONST_METRO_BERCY_LAT          (48.840280818580354F)   // coordinates of Metro Bercy subway station in Paris
-#define CONST_METRO_BERCY_LONG         (2.379762322245707F)    // coordinates of Metro Bercy subway station in Paris
-#define CONST_ESCOLA_NAVAL_LAT         (-22.913357509339527F)  // coordinates of Escola Naval in Rio
-#define CONST_ESCOLA_NAVAL_LONG        (-43.15753771789026F)   // coordinates of Escola Naval in Rio
+#define CONST_EARTH_RADIUS_KM           (6371.0F)               // 6371 km
+#define CONST_COS_PHI_0_INRIA_PARIS     (0.658139837F)          // cos(0.85245092073) where 0.85245092073 represent radians latitude of Inria Paris
+#define CONST_COS_PHI_0_UFF             (0.92114562603F)        // cos(0.3997826147759739) where 0.3997826147759739 represents radians latitude of UFF
+#define CONST_METRO_LIBERTE_LAT         (48.825908013055255F)   // coordinates of Metro Liberte subway station in Paris
+#define CONST_METRO_LIBERTE_LONG        (2.4064333460310094F)   // coordinates of Metro Liberte subway station in Paris
+#define CONST_NOTRE_DAME_DE_PARIS_LAT   (48.85443748F)          // coordinates of Notre Dame de Paris
+#define CONST_NOTRE_DAME_DE_PARIS_LONG  (2.350162268F)          // coordinates of Notre Dame de Paris
+#define CONST_METRO_BERCY_LAT           (48.840280818580354F)   // coordinates of Metro Bercy subway station in Paris
+#define CONST_METRO_BERCY_LONG          (2.379762322245707F)    // coordinates of Metro Bercy subway station in Paris
+#define CONST_ESCOLA_NAVAL_LAT          (-22.913357509339527F)  // coordinates of Escola Naval in Rio
+#define CONST_ESCOLA_NAVAL_LONG         (-43.15753771789026F)   // coordinates of Escola Naval in Rio
 
 // user-select defines
 // make sure CONST_COS_PHI_0 latitude is approximately at the middle of the map
@@ -130,7 +130,7 @@ int main(void) {
     servos_init();
     servos_set(0, _sailbot_vars.sail_trim);
 
-    // init the timers
+    // Init the timers
     db_timer_init();
 
     // Init the wind direction sensor
@@ -140,15 +140,15 @@ int main(void) {
     // Configure GPS without callback
     gps_init(NULL);
 
-    // set timer callbacks
+    // Set timer callbacks
     db_timer_set_periodic_ms(0, TIMEOUT_CHECK_DELAY_MS, &_timeout_check);
     db_timer_set_periodic_ms(1, ADVERTISEMENT_PERIOD_MS, &_advertise);
     db_timer_set_periodic_ms(2, CONTROL_LOOP_PERIOD_MS, &control_loop_callback);
 
     // Wait for radio packets to arrive
     while (1) {
-        // processor idle until an interrupt occurs and is handled
-        // if IMU data is ready, trigger the I2C transfer from outside the interrupt context
+        // Processor idle until an interrupt occurs and is handled
+        // If IMU data is ready, trigger the I2C transfer from outside the interrupt context
         if (lis2mdl_data_ready()) {
             lis2mdl_read_magnetometer(&_sailbot_vars.last_magnetometer);
         }
@@ -313,6 +313,7 @@ void control_loop_callback(void) {
     }
 }
 
+// Not only GPS data. Maybe change function name or send wind sensor data in a different function.
 static void _send_gps_data(const nmea_gprmc_t *data, uint16_t heading, uint16_t wind_angle) {
     int32_t latitude  = (int32_t)(data->latitude * 1e6);
     int32_t longitude = (int32_t)(data->longitude * 1e6);

--- a/projects/03app_sailbot/03app_sailbot.c
+++ b/projects/03app_sailbot/03app_sailbot.c
@@ -164,7 +164,7 @@ int main(void) {
         }
         if (_sailbot_vars.send_log_data) {
             // For now I will read the encoder here, but the measurements must be added as a variable to _sailbot_vars
-            wind_raw_angle = as5048b_i2c_read_raw_angle();
+            wind_raw_angle = (uint16_t)as5048b_i2c_read_angle_degree();
             _send_gps_data(_sailbot_vars.last_gps_data, _sailbot_vars.last_heading, wind_raw_angle);
             _sailbot_vars.send_log_data = false;
         }

--- a/projects/03app_sailbot/03app_sailbot.c
+++ b/projects/03app_sailbot/03app_sailbot.c
@@ -100,7 +100,7 @@ static float  calculate_error(float heading, float bearing);
 static int8_t map_error_to_rudder_angle(float error);
 static void   _timeout_check(void);
 static void   _advertise(void);
-static void   _send_data(const nmea_gprmc_t *data, uint16_t heading, uint16_t wind_angle);
+static void   _send_data(const nmea_gprmc_t *data, uint16_t heading, uint16_t wind_angle, int8_t rudder_angle, int8_t sail_trim));
 
 //=========================== main =========================================
 
@@ -135,7 +135,7 @@ int main(void) {
 
     // Init the wind direction sensor
     as5048b_init();
-    uint16_t wind_raw_angle;
+    uint16_t wind_angle_deg;
 
     // Configure GPS without callback
     gps_init(NULL);
@@ -164,8 +164,8 @@ int main(void) {
         }
         if (_sailbot_vars.send_log_data) {
             // For now I will read the encoder here, but the measurements must be added as a variable to _sailbot_vars
-            wind_raw_angle = (uint16_t)as5048b_i2c_read_angle_degree();
-            _send_data(_sailbot_vars.last_gps_data, _sailbot_vars.last_heading, wind_raw_angle, 0, _sailbot_vars.sail_trim);
+            wind_angle_deg = (uint16_t)as5048b_i2c_read_angle_degree();
+            _send_data(_sailbot_vars.last_gps_data, _sailbot_vars.last_heading, wind_angle_deg, 0, _sailbot_vars.sail_trim);
             _sailbot_vars.send_log_data = false;
         }
         __WFE();

--- a/projects/03app_sailbot/03app_sailbot.c
+++ b/projects/03app_sailbot/03app_sailbot.c
@@ -100,7 +100,7 @@ static float  calculate_error(float heading, float bearing);
 static int8_t map_error_to_rudder_angle(float error);
 static void   _timeout_check(void);
 static void   _advertise(void);
-static void   _send_data(const nmea_gprmc_t *data, uint16_t heading, uint16_t wind_angle, int8_t rudder_angle, int8_t sail_trim));
+static void   _send_data(const nmea_gprmc_t *data, uint16_t heading, uint16_t wind_angle, int8_t rudder_angle, int8_t sail_trim);
 
 //=========================== main =========================================
 

--- a/projects/03app_sailbot/gps.c
+++ b/projects/03app_sailbot/gps.c
@@ -20,8 +20,8 @@
 
 //=========================== defines ==========================================
 
-#define GPS_UART_MAX_BYTES (128U)   ///< max bytes in UART receive buffer, must be greater than 82 bytes for NMEA
-#define UART_SLEEP 1000  ///< delay after calling UART functions, a short delay can result in invalid writing of GPS data after a reset.
+#define GPS_UART_MAX_BYTES (128U)  ///< max bytes in UART receive buffer, must be greater than 82 bytes for NMEA
+#define UART_SLEEP         1000    ///< delay after calling UART functions, a short delay can result in invalid writing of GPS data after a reset.
 
 typedef struct {
     uint8_t      buffer[GPS_UART_MAX_BYTES];  ///< buffer where message received on UART is stored

--- a/projects/03app_sailbot/gps.c
+++ b/projects/03app_sailbot/gps.c
@@ -12,7 +12,7 @@
 #include <nrf.h>
 #include <string.h>
 #include <stdint.h>
-#include "assert.h"
+#include <assert.h>
 #include "gpio.h"
 #include "uart.h"
 #include "gps.h"
@@ -20,7 +20,8 @@
 
 //=========================== defines ==========================================
 
-#define GPS_UART_MAX_BYTES (128U)  ///< max bytes in UART receive buffer, must be greater than 82 bytes for NMEA
+#define GPS_UART_MAX_BYTES (128U)   ///< max bytes in UART receive buffer, must be greater than 82 bytes for NMEA
+#define UART_SLEEP 1000  ///< delay after calling UART functions, a short delay can result in invalid writing of GPS data after a reset.
 
 typedef struct {
     uint8_t      buffer[GPS_UART_MAX_BYTES];  ///< buffer where message received on UART is stored
@@ -232,20 +233,21 @@ void gps_init(gps_rx_cb_t callback) {
 
     // configure UART at 9600 bauds
     db_uart_init(0, &_rx_pin, &_tx_pin, 9600, &uart_callback);
-    db_timer_delay_ms(10);
+    db_timer_delay_ms(UART_SLEEP);
 
     // command the module to increase the baud rate to 38400
     db_uart_write(0, nmea_cmd_set_baud_rate_115200, 20);
 
     // reinit myself at 38400 bauds
     db_uart_init(0, &_rx_pin, &_tx_pin, 115200, &uart_callback);
-    db_timer_delay_ms(10);
+    db_timer_delay_ms(UART_SLEEP);
 
     db_uart_write(0, nmea_cmd_set_nmea_output, 51);
-    db_timer_delay_ms(10);
+    db_timer_delay_ms(UART_SLEEP);
 
     // command to module to use 1hz output data rate
     db_uart_write(0, nmea_cmd_set_1hz_data_rate, 17);
+    db_timer_delay_ms(UART_SLEEP);
 
     _gps_vars.callback = callback;
 }

--- a/projects/projects-sailbot.emProject
+++ b/projects/projects-sailbot.emProject
@@ -3,7 +3,7 @@
   <project Name="03app_sailbot">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_imu(drv)"
+      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_imu(drv);00drv_as5048b(drv)"
       project_directory="03app_sailbot"
       project_type="Executable" />
     <folder Name="Device Files">


### PR DESCRIPTION
# SailBot App changes
## Wind Sensor Integration

- **Wind sensor reading**: Implements wind sensor reading to the SailBot app, capturing wind data from the encoder. This data is now sent as an extra two-byte packet, aimed for display within the PyDotBot interface ([PyDotBot GitHub](https://github.com/DotBots/PyDotBot/)).

## Compatibility and Testing

- **Rudder and Sail Trim Data**: Alongside wind data, two additional bytes representing rudder angle and sail trim are sent for compatibility with PyDotBot code updates linked to the SailBot simulator. These changes are pending testing as of the latest commit (`eebda96887a40c91e26c924177b96c2a1a1bfb45`). The rudder angle currently sends as zero. This needs to be changed. 
- **Action Required**: Modifications are necessary to align these new variables (rudder angle and sail trim) with the simulator GUI, including adjusting value formats to degrees within a specific coordinate system.

## Bug Fix: GPS Data Transmission Post-Reset

- **Issue Resolved**: Fixed a bug where the SailBot failed to send data after a reset, despite successful GPS connection to the satellites. The solution simply involves adding delays to the GPS initialization function, which ensures that the GPS module settles in.

