### PR TITLE
bsp/radio: reduce interframe interval

### DIFF
--- a/bsp/nrf/radio.c
+++ b/bsp/nrf/radio.c
@@ -30,7 +30,7 @@
 #define RADIO_INTERRUPT_PRIORITY 1
 #endif
 
-#define RADIO_TIFS          1000U  ///< Inter frame spacing in us
+#define RADIO_TIFS          150U  ///< Inter frame spacing in us
 #define RADIO_SHORTS_COMMON (RADIO_SHORTS_READY_START_Enabled << RADIO_SHORTS_READY_START_Pos) |                 \
                                 (RADIO_SHORTS_END_DISABLE_Enabled << RADIO_SHORTS_END_DISABLE_Pos) |             \
                                 (RADIO_SHORTS_ADDRESS_RSSISTART_Enabled << RADIO_SHORTS_ADDRESS_RSSISTART_Pos) | \


### PR DESCRIPTION
The TIFS value was set to 1000us during debugging although the datasheet gives timing values that are at most 140us for a TIFS of 150us.