### PR TITLE
Enable fastest posible transmission time for the radio

### DIFF
--- a/bsp/nrf/radio.c
+++ b/bsp/nrf/radio.c
@@ -30,7 +30,7 @@
 #define RADIO_INTERRUPT_PRIORITY 1
 #endif
 
-#define RADIO_TIFS          0U  ///< Inter frame spacing in us. zero maens IFS is enforced by software, not the hardware
+#define RADIO_TIFS          0U  ///< Inter frame spacing in us. zero means IFS is enforced by software, not the hardware
 #define RADIO_SHORTS_COMMON (RADIO_SHORTS_READY_START_Enabled << RADIO_SHORTS_READY_START_Pos) |                 \
                                 (RADIO_SHORTS_END_DISABLE_Enabled << RADIO_SHORTS_END_DISABLE_Pos) |             \
                                 (RADIO_SHORTS_ADDRESS_RSSISTART_Enabled << RADIO_SHORTS_ADDRESS_RSSISTART_Pos) | \

--- a/bsp/nrf/radio.c
+++ b/bsp/nrf/radio.c
@@ -30,7 +30,7 @@
 #define RADIO_INTERRUPT_PRIORITY 1
 #endif
 
-#define RADIO_TIFS          150U  ///< Inter frame spacing in us
+#define RADIO_TIFS          0U  ///< Inter frame spacing in us. zero maens IFS is enforced by software, not the hardware
 #define RADIO_SHORTS_COMMON (RADIO_SHORTS_READY_START_Enabled << RADIO_SHORTS_READY_START_Pos) |                 \
                                 (RADIO_SHORTS_END_DISABLE_Enabled << RADIO_SHORTS_END_DISABLE_Pos) |             \
                                 (RADIO_SHORTS_ADDRESS_RSSISTART_Enabled << RADIO_SHORTS_ADDRESS_RSSISTART_Pos) | \
@@ -151,6 +151,10 @@ void db_radio_init(radio_cb_t callback, db_radio_ble_mode_t mode) {
 
     // Inter frame spacing in us
     NRF_RADIO->TIFS = RADIO_TIFS;
+
+    // Enable Fast TX Ramp Up
+    NRF_RADIO->MODECNF0 = (RADIO_MODECNF0_RU_Fast << RADIO_MODECNF0_RU_Pos) |
+                          (RADIO_MODECNF0_DTX_Center << RADIO_MODECNF0_DTX_Pos);
 
     // CRC Config
     NRF_RADIO->CRCCNF  = (RADIO_CRCCNF_LEN_Three << RADIO_CRCCNF_LEN_Pos) | (RADIO_CRCCNF_SKIPADDR_Skip << RADIO_CRCCNF_SKIPADDR_Pos);  // Checksum uses 3 bytes, and is enabled.


### PR DESCRIPTION
Two proposed changes:
- set `TIFS` to 0
- enable Fast TX Ramp Up

This reduces the overhead prep-time of the radio from `370us` to `140us`.

This changes were tested with the project:
- `01bsp_radio_txrx`
- `01bsp_radio_lr_txrx`

Both compile and work correctly