### PR TITLE
bsp/timer_hf: extend api so all available timer peripherals can be used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ endif
 
 ifneq (,$(filter nrf52833dk,$(BUILD_TARGET)))
   PROJECTS := $(filter-out 01crypto_%,$(PROJECTS))
+  # Bootloader not supported on nrf52833dk
+  BOOTLOADER :=
 endif
 
 # remove incompatible apps (nrf5340) for nrf52833dk/nrf52840dk build

--- a/bsp/nrf/lh2.c
+++ b/bsp/nrf/lh2.c
@@ -47,6 +47,7 @@
 #define LH2_MAX_DATA_VALID_TIME_US             2000000                                                        //< Data older than this is considered outdate and should be erased (in microseconds)
 #define LH2_SWEEP_PERIOD_US                    20000                                                          ///< time, in microseconds, between two full rotations of the LH2 motor
 #define LH2_SWEEP_PERIOD_THRESHOLD_US          1000                                                           ///< How close a LH2 pulse must arrive relative to LH2_SWEEP_PERIOD_US, to be considered the same type of sweep (first sweep or second second). (in microseconds)
+#define LH2_TIMER_DEV                          2                                                              ///< Timer device used for LH2
 
 #if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
 #define NRF_SPIM         NRF_SPIM4_S
@@ -967,7 +968,7 @@ void db_lh2_process_location(db_lh2_t *lh2) {
 void _initialize_ts4231(const gpio_t *gpio_d, const gpio_t *gpio_e) {
 
     // Configure the wait timer
-    db_timer_hf_init();
+    db_timer_hf_init(LH2_TIMER_DEV);
 
     // Filip's code define these pins as inputs, and then changes them quickly to outputs. Not sure why, but it works.
     _lh2_pin_set_input(gpio_d);
@@ -976,33 +977,33 @@ void _initialize_ts4231(const gpio_t *gpio_d, const gpio_t *gpio_e) {
     // start the TS4231 initialization
     // Wiggle the Envelope and Data pins
     _lh2_pin_set_output(gpio_e);
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTSET = 1 << gpio_e->pin;  // set pin HIGH
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTCLR = 1 << gpio_e->pin;  // set pin LOW
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTSET = 1 << gpio_e->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     _lh2_pin_set_output(gpio_d);
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_d->port]->OUTSET = 1 << gpio_d->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     // Turn the pins back to inputs
     _lh2_pin_set_input(gpio_d);
     _lh2_pin_set_input(gpio_e);
     // finally, wait 1 milisecond
-    db_timer_hf_delay_us(1000);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 1000);
 
     // Send the configuration magic number/sequence
     uint16_t config_val = 0x392B;
     // Turn the Data and Envelope lines back to outputs and clear them.
     _lh2_pin_set_output(gpio_e);
     _lh2_pin_set_output(gpio_d);
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_d->port]->OUTCLR = 1 << gpio_d->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTCLR = 1 << gpio_e->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     // Send the magic configuration value, MSB first.
     for (uint8_t i = 0; i < 15; i++) {
 
@@ -1014,68 +1015,68 @@ void _initialize_ts4231(const gpio_t *gpio_d, const gpio_t *gpio_e) {
         }
 
         // Toggle the Envelope line as a clock.
-        db_timer_hf_delay_us(10);
+        db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
         nrf_port[gpio_e->port]->OUTSET = 1 << gpio_e->pin;
-        db_timer_hf_delay_us(10);
+        db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
         nrf_port[gpio_e->port]->OUTCLR = 1 << gpio_e->pin;
-        db_timer_hf_delay_us(10);
+        db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     }
     // Finish send sequence and turn pins into inputs again.
     nrf_port[gpio_d->port]->OUTCLR = 1 << gpio_d->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTSET = 1 << gpio_e->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_d->port]->OUTSET = 1 << gpio_d->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     _lh2_pin_set_input(gpio_d);
     _lh2_pin_set_input(gpio_e);
     // Finish by waiting 10usec
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
 
     // Now read back the sequence that the TS4231 answers.
     _lh2_pin_set_output(gpio_e);
     _lh2_pin_set_output(gpio_d);
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_d->port]->OUTCLR = 1 << gpio_d->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTCLR = 1 << gpio_e->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_d->port]->OUTSET = 1 << gpio_d->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTSET = 1 << gpio_e->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     // Set Data pin as an input, to receive the data
     _lh2_pin_set_input(gpio_d);
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTCLR = 1 << gpio_e->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     // Use the Envelope pin to output a clock while the data arrives.
     for (uint8_t i = 0; i < 14; i++) {
         nrf_port[gpio_e->port]->OUTSET = 1 << gpio_e->pin;
-        db_timer_hf_delay_us(10);
+        db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
         nrf_port[gpio_e->port]->OUTCLR = 1 << gpio_e->pin;
-        db_timer_hf_delay_us(10);
+        db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     }
 
     // Finish the configuration procedure
     _lh2_pin_set_output(gpio_d);
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTSET = 1 << gpio_e->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_d->port]->OUTSET = 1 << gpio_d->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
 
     nrf_port[gpio_e->port]->OUTCLR = 1 << gpio_e->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_d->port]->OUTCLR = 1 << gpio_d->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
     nrf_port[gpio_e->port]->OUTSET = 1 << gpio_e->pin;
-    db_timer_hf_delay_us(10);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 10);
 
     _lh2_pin_set_input(gpio_d);
     _lh2_pin_set_input(gpio_e);
 
-    db_timer_hf_delay_us(50000);
+    db_timer_hf_delay_us(LH2_TIMER_DEV, 50000);
 }
 
 uint64_t _demodulate_light(uint8_t *sample_buffer) {  // bad input variable name!!
@@ -1701,7 +1702,7 @@ uint8_t _select_sweep(db_lh2_t *lh2, uint8_t polynomial, uint32_t timestamp) {
     // TODO: check the exact, per-mode period of each polynomial instead of using a blanket 20ms
 
     uint8_t  basestation = polynomial >> 1;  ///< each base station uses 2 polynomials. integer dividing by 2 maps the polynomial number to the basestation number.
-    uint32_t now         = db_timer_hf_now();
+    uint32_t now         = db_timer_hf_now(LH2_TIMER_DEV);
     // check that current data stored is not too old.
     for (size_t sweep = 0; sweep < 2; sweep++) {
         if (now - lh2->timestamps[0][basestation] > LH2_MAX_DATA_VALID_TIME_US) {
@@ -1799,7 +1800,7 @@ void SPIM_IRQ_HANDLER(void) {
         // Reenable the PPI channel
         db_lh2_start();
         // Read the current time.
-        uint32_t timestamp = db_timer_hf_now();
+        uint32_t timestamp = db_timer_hf_now(LH2_TIMER_DEV);
         // Add new reading to the ring buffer
         _add_to_spi_ring_buffer(&_lh2_vars.data, _lh2_vars.spi_rx_buffer, timestamp);
     }

--- a/bsp/nrf/timer_hf.c
+++ b/bsp/nrf/timer_hf.c
@@ -18,21 +18,13 @@
 
 //=========================== define ===========================================
 
-#if defined(NRF5340_XXAA)
-#if defined(NRF_APPLICATION)
-#define TIMER_HF (NRF_TIMER2_S)  ///< Backend TIMER peripheral used by the timer
-#elif defined(NRF_NETWORK)
-#define TIMER_HF (NRF_TIMER2_NS)  ///< Backend TIMER peripheral used by the timer
-#endif
-#define TIMER_HF_IRQ      (TIMER2_IRQn)        ///< IRQ corresponding to the TIMER used
-#define TIMER_HF_ISR      (TIMER2_IRQHandler)  ///< ISR function handler corresponding to the TIMER used
-#define TIMER_HF_CB_CHANS (TIMER2_CC_NUM - 1)  ///< Number of channels that can be used for periodic callbacks
-#else
-#define TIMER_HF          (NRF_TIMER4)         ///< Backend TIMER peripheral used by the timer
-#define TIMER_HF_IRQ      (TIMER4_IRQn)        ///< IRQ corresponding to the TIMER used
-#define TIMER_HF_ISR      (TIMER4_IRQHandler)  ///< ISR function handler corresponding to the TIMER used
-#define TIMER_HF_CB_CHANS (TIMER4_CC_NUM - 1)  ///< Number of channels that can be used for periodic callbacks
-#endif
+#define TIMER_MAX_CHANNELS (6U)
+
+typedef struct {
+    NRF_TIMER_Type *p;
+    IRQn_Type       irq;
+    uint8_t         cc_num;
+} timer_hf_conf_t;
 
 typedef struct {
     uint32_t      period_us;  ///< Period in ticks between each callback
@@ -41,110 +33,190 @@ typedef struct {
 } timer_hf_callback_t;
 
 typedef struct {
-    timer_hf_callback_t timer_callback[TIMER_HF_CB_CHANS];  ///< List of timer callback structs
-    bool                running;                            ///< Whether the delay timer is running
+    timer_hf_callback_t timer_callback[TIMER_MAX_CHANNELS];  ///< List of timer callback structs
+    bool                running;                             ///< Whether the delay timer is running
 } timer_hf_vars_t;
 
 //=========================== variables ========================================
 
-static timer_hf_vars_t _timer_hf_vars;
+static const timer_hf_conf_t _devs[TIMER_COUNT] = {
+#if defined(NRF5340_XXAA)
+    {
+#if defined(NRF_NETWORK)
+        .p = NRF_TIMER0_NS,
+#else
+        .p = NRF_TIMER0_S,
+#endif
+        .irq    = TIMER0_IRQn,
+        .cc_num = TIMER0_CC_NUM - 1,
+    },
+    {
+#if defined(NRF_NETWORK)
+        .p = NRF_TIMER1_NS,
+#else
+        .p = NRF_TIMER1_S,
+#endif
+        .irq    = TIMER1_IRQn,
+        .cc_num = TIMER1_CC_NUM - 1,
+    },
+    {
+#if defined(NRF_NETWORK)
+        .p = NRF_TIMER2_NS,
+#else
+        .p = NRF_TIMER2_S,
+#endif
+        .irq    = TIMER2_IRQn,
+        .cc_num = TIMER2_CC_NUM - 1,
+    },
+#else
+    {
+        .p      = NRF_TIMER0,
+        .irq    = TIMER0_IRQn,
+        .cc_num = TIMER0_CC_NUM - 1,
+    },
+    {
+        .p      = NRF_TIMER1,
+        .irq    = TIMER1_IRQn,
+        .cc_num = TIMER1_CC_NUM - 1,
+    },
+    {
+        .p      = NRF_TIMER2,
+        .irq    = TIMER2_IRQn,
+        .cc_num = TIMER2_CC_NUM - 1,
+    },
+    {
+        .p      = NRF_TIMER3,
+        .irq    = TIMER3_IRQn,
+        .cc_num = TIMER3_CC_NUM - 1,
+    },
+    {
+        .p      = NRF_TIMER4,
+        .irq    = TIMER4_IRQn,
+        .cc_num = TIMER4_CC_NUM - 1,
+    },
+#endif
+};
+
+static timer_hf_vars_t _timer_hf_vars[TIMER_COUNT] = { 0 };
 
 //=========================== public ===========================================
 
-void db_timer_hf_init(void) {
+void db_timer_hf_init(timer_hf_t timer) {
     // No delay is running after initialization
-    _timer_hf_vars.running = false;
+    _timer_hf_vars[timer].running = false;
 
     // Configure and start High Frequency clock
     db_hfclk_init();
 
     // Configure the timer
-    TIMER_HF->TASKS_CLEAR = 1;
-    TIMER_HF->PRESCALER   = 4;  // Run TIMER at 1MHz
-    TIMER_HF->BITMODE     = (TIMER_BITMODE_BITMODE_32Bit << TIMER_BITMODE_BITMODE_Pos);
-    TIMER_HF->INTENSET    = (1 << (TIMER_INTENSET_COMPARE0_Pos + TIMER_HF_CB_CHANS));
-    NVIC_EnableIRQ(TIMER_HF_IRQ);
+    _devs[timer].p->TASKS_CLEAR = 1;
+    _devs[timer].p->PRESCALER   = 4;  // Run TIMER at 1MHz
+    _devs[timer].p->BITMODE     = (TIMER_BITMODE_BITMODE_32Bit << TIMER_BITMODE_BITMODE_Pos);
+    _devs[timer].p->INTENSET    = (1 << (TIMER_INTENSET_COMPARE0_Pos + _devs[timer].cc_num));
+    NVIC_EnableIRQ(_devs[timer].irq);
 
     // Start the timer
-    TIMER_HF->TASKS_START = 1;
+    _devs[timer].p->TASKS_START = 1;
 }
 
-uint32_t db_timer_hf_now(void) {
-    TIMER_HF->TASKS_CAPTURE[TIMER_HF_CB_CHANS] = 1;
-    return TIMER_HF->CC[TIMER_HF_CB_CHANS];
+uint32_t db_timer_hf_now(timer_hf_t timer) {
+    _devs[timer].p->TASKS_CAPTURE[_devs[timer].cc_num] = 1;
+    return _devs[timer].p->CC[_devs[timer].cc_num];
 }
 
-void db_timer_hf_set_periodic_us(uint8_t channel, uint32_t us, timer_hf_cb_t cb) {
-    assert(channel >= 0 && channel < TIMER_HF_CB_CHANS + 1);  // Make sure the required channel is correct
-    assert(cb);                                               // Make sure the callback function is valid
+void db_timer_hf_set_periodic_us(timer_hf_t timer, uint8_t channel, uint32_t us, timer_hf_cb_t cb) {
+    assert(channel >= 0 && channel < _devs[timer].cc_num + 1);  // Make sure the required channel is correct
+    assert(cb);                                                 // Make sure the callback function is valid
 
-    _timer_hf_vars.timer_callback[channel].period_us = us;
-    _timer_hf_vars.timer_callback[channel].one_shot  = false;
-    _timer_hf_vars.timer_callback[channel].callback  = cb;
-    TIMER_HF->INTENSET                               = (1 << (TIMER_INTENSET_COMPARE0_Pos + channel));
-    TIMER_HF->TASKS_CAPTURE[channel]                 = 1;
-    TIMER_HF->CC[channel] += _timer_hf_vars.timer_callback[channel].period_us;
+    _timer_hf_vars[timer].timer_callback[channel].period_us = us;
+    _timer_hf_vars[timer].timer_callback[channel].one_shot  = false;
+    _timer_hf_vars[timer].timer_callback[channel].callback  = cb;
+    _devs[timer].p->INTENSET                                = (1 << (TIMER_INTENSET_COMPARE0_Pos + channel));
+    _devs[timer].p->TASKS_CAPTURE[channel]                  = 1;
+    _devs[timer].p->CC[channel] += _timer_hf_vars[timer].timer_callback[channel].period_us;
 }
 
-void db_timer_hf_set_oneshot_us(uint8_t channel, uint32_t us, timer_hf_cb_t cb) {
-    assert(channel >= 0 && channel < TIMER_HF_CB_CHANS + 1);  // Make sure the required channel is correct
-    assert(cb);                                               // Make sure the callback function is valid
+void db_timer_hf_set_oneshot_us(timer_hf_t timer, uint8_t channel, uint32_t us, timer_hf_cb_t cb) {
+    assert(channel >= 0 && channel < _devs[timer].cc_num + 1);  // Make sure the required channel is correct
+    assert(cb);                                                 // Make sure the callback function is valid
 
-    _timer_hf_vars.timer_callback[channel].period_us = us;
-    _timer_hf_vars.timer_callback[channel].one_shot  = true;
-    _timer_hf_vars.timer_callback[channel].callback  = cb;
-    TIMER_HF->INTENSET                               = (1 << (TIMER_INTENSET_COMPARE0_Pos + channel));
-    TIMER_HF->TASKS_CAPTURE[channel]                 = 1;
-    TIMER_HF->CC[channel] += _timer_hf_vars.timer_callback[channel].period_us;
+    _timer_hf_vars[timer].timer_callback[channel].period_us = us;
+    _timer_hf_vars[timer].timer_callback[channel].one_shot  = true;
+    _timer_hf_vars[timer].timer_callback[channel].callback  = cb;
+    _devs[timer].p->INTENSET                                = (1 << (TIMER_INTENSET_COMPARE0_Pos + channel));
+    _devs[timer].p->TASKS_CAPTURE[channel]                  = 1;
+    _devs[timer].p->CC[channel] += _timer_hf_vars[timer].timer_callback[channel].period_us;
 }
 
-void db_timer_hf_set_oneshot_ms(uint8_t channel, uint32_t ms, timer_hf_cb_t cb) {
-    db_timer_hf_set_oneshot_us(channel, ms * 1000UL, cb);
+void db_timer_hf_set_oneshot_ms(timer_hf_t timer, uint8_t channel, uint32_t ms, timer_hf_cb_t cb) {
+    db_timer_hf_set_oneshot_us(timer, channel, ms * 1000UL, cb);
 }
 
-void db_timer_hf_set_oneshot_s(uint8_t channel, uint32_t s, timer_hf_cb_t cb) {
-    db_timer_hf_set_oneshot_us(channel, s * 1000UL * 1000UL, cb);
+void db_timer_hf_set_oneshot_s(timer_hf_t timer, uint8_t channel, uint32_t s, timer_hf_cb_t cb) {
+    db_timer_hf_set_oneshot_us(timer, channel, s * 1000UL * 1000UL, cb);
 }
 
-void db_timer_hf_delay_us(uint32_t us) {
-    TIMER_HF->TASKS_CAPTURE[TIMER_HF_CB_CHANS] = 1;
-    TIMER_HF->CC[TIMER_HF_CB_CHANS] += us;
-    _timer_hf_vars.running = true;
-    while (_timer_hf_vars.running) {
+void db_timer_hf_delay_us(timer_hf_t timer, uint32_t us) {
+    _devs[timer].p->TASKS_CAPTURE[_devs[timer].cc_num] = 1;
+    _devs[timer].p->CC[_devs[timer].cc_num] += us;
+    _timer_hf_vars[timer].running = true;
+    while (_timer_hf_vars[timer].running) {
         __WFE();
         __SEV();
         __WFE();
     }
 }
 
-void db_timer_hf_delay_ms(uint32_t ms) {
-    db_timer_hf_delay_us(ms * 1000UL);
+void db_timer_hf_delay_ms(timer_hf_t timer, uint32_t ms) {
+    db_timer_hf_delay_us(timer, ms * 1000UL);
 }
 
-void db_timer_hf_delay_s(uint32_t s) {
-    db_timer_hf_delay_us(s * 1000UL * 1000UL);
+void db_timer_hf_delay_s(timer_hf_t timer, uint32_t s) {
+    db_timer_hf_delay_us(timer, s * 1000UL * 1000UL);
 }
 
 //=========================== interrupt ========================================
 
-void TIMER_HF_ISR(void) {
-    if (TIMER_HF->EVENTS_COMPARE[TIMER_HF_CB_CHANS] == 1) {
-        TIMER_HF->EVENTS_COMPARE[TIMER_HF_CB_CHANS] = 0;
-        _timer_hf_vars.running                      = false;
+void _timer_hf_isr(timer_hf_t timer) {
+    if (_devs[timer].p->EVENTS_COMPARE[_devs[timer].cc_num] == 1) {
+        _devs[timer].p->EVENTS_COMPARE[_devs[timer].cc_num] = 0;
+        _timer_hf_vars[timer].running                       = false;
         __SEV();
     }
 
-    for (uint8_t channel = 0; channel < TIMER_HF_CB_CHANS; ++channel) {
-        if (TIMER_HF->EVENTS_COMPARE[channel] == 1) {
-            TIMER_HF->EVENTS_COMPARE[channel] = 0;
-            if (_timer_hf_vars.timer_callback[channel].one_shot) {
-                TIMER_HF->INTENCLR = (1 << (TIMER_INTENCLR_COMPARE0_Pos + channel));
+    for (uint8_t channel = 0; channel < _devs[timer].cc_num; ++channel) {
+        if (_devs[timer].p->EVENTS_COMPARE[channel] == 1) {
+            _devs[timer].p->EVENTS_COMPARE[channel] = 0;
+            if (_timer_hf_vars[timer].timer_callback[channel].one_shot) {
+                _devs[timer].p->INTENCLR = (1 << (TIMER_INTENCLR_COMPARE0_Pos + channel));
             } else {
-                TIMER_HF->CC[channel] += _timer_hf_vars.timer_callback[channel].period_us;
+                _devs[timer].p->CC[channel] += _timer_hf_vars[timer].timer_callback[channel].period_us;
             }
-            if (_timer_hf_vars.timer_callback[channel].callback) {
-                _timer_hf_vars.timer_callback[channel].callback();
+            if (_timer_hf_vars[timer].timer_callback[channel].callback) {
+                _timer_hf_vars[timer].timer_callback[channel].callback();
             }
         }
     }
 }
+
+void TIMER0_IRQHandler(void) {
+    _timer_hf_isr(0);
+}
+
+void TIMER1_IRQHandler(void) {
+    _timer_hf_isr(1);
+}
+
+void TIMER2_IRQHandler(void) {
+    _timer_hf_isr(2);
+}
+
+#if !defined(NRF5340_XXAA)
+void TIMER3_IRQHandler(void) {
+    _timer_hf_isr(3);
+}
+
+void TIMER4_IRQHandler(void) {
+    _timer_hf_isr(4);
+}
+#endif

--- a/bsp/timer_hf.h
+++ b/bsp/timer_hf.h
@@ -17,75 +17,88 @@
 
 //=========================== defines ==========================================
 
+typedef uint8_t timer_hf_t;  ///< TIMER peripheral index
+
 typedef void (*timer_hf_cb_t)(void);  ///< Callback function prototype, it is called when the timer fires an event
 
 //=========================== prototypes =======================================
 
 /**
  * @brief Configure a high frequency timer with microsecond precision
+ *
+ * @param[in] timer     timer reference used
  */
-void db_timer_hf_init(void);
+void db_timer_hf_init(timer_hf_t timer);
 
 /**
  * @brief Return the current timer time in microseconds
+ *
+ * @param[in] timer     timer reference used
  */
-uint32_t db_timer_hf_now(void);
+uint32_t db_timer_hf_now(timer_hf_t timer);
 
 /**
  * @brief Set a callback to be called periodically using the high frequency timer
  *
+ * @param[in] timer     timer reference used
  * @param[in] channel   TIMER channel used
  * @param[in] us        periodicity in microseconds
  * @param[in] cb        callback function
  */
-void db_timer_hf_set_periodic_us(uint8_t channel, uint32_t us, timer_hf_cb_t cb);
+void db_timer_hf_set_periodic_us(timer_hf_t timer, uint8_t channel, uint32_t us, timer_hf_cb_t cb);
 
 /**
  * @brief Set a callback to be called once after an amount of microseconds
  *
+ * @param[in] timer     timer reference used
  * @param[in] channel   TIMER channel used
  * @param[in] us        delay in microseconds
  * @param[in] cb        callback function
  */
-void db_timer_hf_set_oneshot_us(uint8_t channel, uint32_t us, timer_hf_cb_t cb);
+void db_timer_hf_set_oneshot_us(timer_hf_t timer, uint8_t channel, uint32_t us, timer_hf_cb_t cb);
 
 /**
  * @brief Set a callback to be called once after an amount of milliseconds
  *
+ * @param[in] timer     timer reference used
  * @param[in] channel   TIMER channel used
  * @param[in] ms        delay in milliseconds
  * @param[in] cb        callback function
  */
-void db_timer_hf_set_oneshot_ms(uint8_t channel, uint32_t ms, timer_hf_cb_t cb);
+void db_timer_hf_set_oneshot_ms(timer_hf_t timer, uint8_t channel, uint32_t ms, timer_hf_cb_t cb);
 
 /**
  * @brief Set a callback to be called after an amount of seconds
  *
+ * @param[in] timer     timer reference used
  * @param[in] channel   TIMER channel used
  * @param[in] s         delay in seconds
  * @param[in] cb        callback function
  */
-void db_timer_hf_set_oneshot_s(uint8_t channel, uint32_t s, timer_hf_cb_t cb);
+void db_timer_hf_set_oneshot_s(timer_hf_t timer, uint8_t channel, uint32_t s, timer_hf_cb_t cb);
 
 /**
  * @brief Add a delay in us using the high frequency timer
  *
- * @param[in] us    delay in us
+ * @param[in] timer     timer reference used
+ * @param[in] us        delay in us
  */
-void db_timer_hf_delay_us(uint32_t us);
+void db_timer_hf_delay_us(timer_hf_t timer, uint32_t us);
 
 /**
  * @brief Add a delay in milliseconds using the high frequency timer
  *
- * @param[in] ms    delay in milliseconds
+ * @param[in] timer     timer reference used
+ * @param[in] ms        delay in milliseconds
  */
-void db_timer_hf_delay_ms(uint32_t ms);
+void db_timer_hf_delay_ms(timer_hf_t timer, uint32_t ms);
 
 /**
  * @brief Add a delay in seconds using the high frequency timer
  *
- * @param[in] s delay in seconds
+ * @param[in] timer     timer reference used
+ * @param[in] s         delay in seconds
  */
-void db_timer_hf_delay_s(uint32_t s);
+void db_timer_hf_delay_s(timer_hf_t timer, uint32_t s);
 
 #endif

--- a/drv/log_flash/log_flash.c
+++ b/drv/log_flash/log_flash.c
@@ -20,6 +20,7 @@
 //=========================== defines ==========================================
 
 #define DB_LOG_FLASH_START ((DB_FLASH_PAGE_SIZE * DB_FLASH_PAGE_NUM) / 2)
+#define DB_LOG_FLASH_TIMER (1)
 
 //=========================== variables ========================================
 
@@ -29,7 +30,7 @@ static uint32_t *_write_address = (uint32_t *)(DB_LOG_FLASH_START + DB_FLASH_OFF
 
 void db_log_flash_init(db_log_data_type_t type) {
     // Initialize the timer hf used to timestamp the logs
-    db_timer_hf_init();
+    db_timer_hf_init(DB_LOG_FLASH_TIMER);
 
     // Erase all pages that can be used to store the logs
     for (uint16_t page = DB_FLASH_PAGE_NUM / 2; page < DB_FLASH_PAGE_NUM; page++) {
@@ -52,7 +53,7 @@ void db_log_flash_write(const void *data, size_t len) {
         return;
     }
 
-    const uint32_t now = db_timer_hf_now();
+    const uint32_t now = db_timer_hf_now(DB_LOG_FLASH_TIMER);
     db_nvmc_write(_write_address++, &now, sizeof(uint32_t));
     db_nvmc_write(_write_address, data, len);
     _write_address += (len >> 2);

--- a/otap/bootloader/main.c
+++ b/otap/bootloader/main.c
@@ -43,6 +43,8 @@
 #define DB_UART_MAX_BYTES (64U)
 #define DB_UART_BAUDRATE  (1000000U)
 
+#define DB_TIMER_DEV (0)  // Timer device index
+
 typedef struct {
     db_partitions_table_t table;
     uint8_t               uart_byte;
@@ -146,8 +148,8 @@ int main(void) {
         db_gpio_init(&db_led4, DB_GPIO_OUT);
         db_gpio_init(&db_btn1, DB_GPIO_IN_PU);
         db_gpio_init(&db_btn2, DB_GPIO_IN_PU);
-        db_timer_hf_init();
-        db_timer_hf_set_periodic_us(0, 100000, &_blink_led4);
+        db_timer_hf_init(DB_TIMER_DEV);
+        db_timer_hf_set_periodic_us(DB_TIMER_DEV, 0, 100000, &_blink_led4);
         db_uart_init(0, &db_uart_rx, &db_uart_tx, DB_UART_BAUDRATE, &_uart_callback);
         db_ota_init(&_bootloader_ota_config);
     }

--- a/projects/01bsp_i2c/01bsp_i2c.c
+++ b/projects/01bsp_i2c/01bsp_i2c.c
@@ -42,7 +42,7 @@ typedef struct {
  */
 int main(void) {
     db_board_init();
-    db_timer_hf_init();
+    db_timer_hf_init(0);
     db_i2c_init(&db_scl, &db_sda);
     db_i2c_begin();
     uint8_t who_am_i;
@@ -79,7 +79,7 @@ int main(void) {
         data.z |= tmp << 8;
         db_i2c_end();
         printf("x: %i, y: %i, z: %i\n", data.x, data.y, data.z);
-        db_timer_hf_delay_ms(200);
+        db_timer_hf_delay_ms(0, 200);
     }
 
     // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.

--- a/projects/01bsp_radio_txrx/01bsp_radio_txrx.c
+++ b/projects/01bsp_radio_txrx/01bsp_radio_txrx.c
@@ -65,7 +65,7 @@ int main(void) {
     //=========================== Initialize GPIO and timer =====================
 
     db_gpio_init(&_dbg_pin, DB_GPIO_OUT);
-    db_timer_hf_init();
+    db_timer_hf_init(0);
 
     //=========================== Configure Radio ===============================
 
@@ -76,6 +76,6 @@ int main(void) {
     while (1) {
         db_radio_disable();
         db_radio_tx((uint8_t *)packet_tx, sizeof(packet_tx) / sizeof(packet_tx[0]));
-        db_timer_hf_delay_ms(DELAY_MS);
+        db_timer_hf_delay_ms(0, DELAY_MS);
     }
 }

--- a/projects/01bsp_rng/01bsp_rng.c
+++ b/projects/01bsp_rng/01bsp_rng.c
@@ -19,7 +19,7 @@
  *  @brief The program starts executing here.
  */
 int main(void) {
-    db_timer_hf_init();
+    db_timer_hf_init(0);
     db_rng_init();
 
     while (1) {
@@ -27,7 +27,7 @@ int main(void) {
         db_rng_read(&value);
         printf("Random value: %d\n", value);
 
-        db_timer_hf_delay_ms(100);
+        db_timer_hf_delay_ms(0, 100);
     }
 
     // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.

--- a/projects/01bsp_saadc/01bsp_saadc.c
+++ b/projects/01bsp_saadc/01bsp_saadc.c
@@ -16,7 +16,7 @@
 //=========================== main =============================================
 
 int main(void) {
-    db_timer_hf_init();
+    db_timer_hf_init(0);
     db_saadc_init(DB_SAADC_RESOLUTION_12BIT);
 
     while (1) {
@@ -35,6 +35,6 @@ int main(void) {
         printf("VDDH: %i\n", value);
         db_saadc_read(DB_SAADC_INPUT_VDD, &value);
         printf("VDD : %i\n", value);
-        db_timer_hf_delay_ms(100);
+        db_timer_hf_delay_ms(0, 100);
     }
 }

--- a/projects/01bsp_timer_hf/01bsp_timer_hf.c
+++ b/projects/01bsp_timer_hf/01bsp_timer_hf.c
@@ -19,9 +19,7 @@
 #include "gpio.h"
 #include "timer_hf.h"
 
-//=========================== defines =========================================
-
-//=========================== variables =========================================
+//=========================== variables ====================================
 
 #if defined(DB_LED2_PORT)
 static const gpio_t led = { .port = DB_LED2_PORT, .pin = DB_LED2_PIN };
@@ -29,7 +27,7 @@ static const gpio_t led = { .port = DB_LED2_PORT, .pin = DB_LED2_PIN };
 static const gpio_t led = { .port = DB_LED1_PORT, .pin = DB_LED1_PIN };
 #endif
 
-//=========================== main =========================================
+//=========================== callbacks ====================================
 
 static void message_callback(void) {
     printf("Hello from callback\n");
@@ -43,23 +41,21 @@ static void led_callback(void) {
     db_gpio_toggle(&led);
 }
 
-/**
- *  @brief The program starts executing here.
- */
+//=========================== main =========================================
+
 int main(void) {
     db_gpio_init(&led, DB_GPIO_OUT);
     db_gpio_set(&led);
-    db_timer_hf_init();
-    db_timer_hf_set_periodic_us(0, 2000000, &message_callback);
-    db_timer_hf_set_periodic_us(1, 500000, &led_callback);
-    db_timer_hf_set_oneshot_ms(2, 1000, &message_one_shot_callback);
+    db_timer_hf_init(0);
+    db_timer_hf_init(1);
+    db_timer_hf_init(2);
+    db_timer_hf_set_periodic_us(0, 0, 2000000, &message_callback);
+    db_timer_hf_set_periodic_us(1, 1, 500000, &led_callback);
+    db_timer_hf_set_oneshot_ms(2, 2, 1000, &message_one_shot_callback);
     while (1) {
         printf("Hello dotbot\n");
-        db_timer_hf_delay_ms(500);
+        db_timer_hf_delay_ms(0, 500);
         printf("Hello dotbot again\n");
-        db_timer_hf_delay_s(1);
+        db_timer_hf_delay_s(0, 1);
     }
-
-    // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.
-    __NOP();
 }

--- a/projects/01drv_as5048b/01drv_as5048b.c
+++ b/projects/01drv_as5048b/01drv_as5048b.c
@@ -22,11 +22,11 @@ int main(void) {
     // Init the encoder I2C communication
     as5048b_init();
     // Init high frequency clock
-    db_timer_hf_init();
+    db_timer_hf_init(0);
 
     while (1) {
         float angle_degrees = as5048b_i2c_read_angle_degree();
         printf("Angle degrees: %.1f\n", angle_degrees);
-        db_timer_hf_delay_ms(50);
+        db_timer_hf_delay_ms(0, 50);
     }
 }

--- a/projects/01drv_ism330/01drv_ism330.c
+++ b/projects/01drv_ism330/01drv_ism330.c
@@ -14,8 +14,6 @@
 #include "timer_hf.h"
 #include "ism330.h"
 
-//=========================== defines ==========================================
-
 //=========================== variables ========================================
 
 static ism330_acc_data_t  acc_data;
@@ -27,22 +25,19 @@ int main(void) {
 
     db_board_init();
     db_ism330_init(&db_sda, &db_scl);
-    db_timer_hf_init();
+    db_timer_hf_init(0);
 
-    db_timer_hf_delay_ms(500);
+    db_timer_hf_delay_ms(0, 500);
     // read accelerometer and gyroscope data in a loop
     while (1) {
         // Read Accelerometer data
         db_ism330_accel_read(&acc_data);
-        db_timer_hf_delay_ms(250);
+        db_timer_hf_delay_ms(0, 250);
         __NOP();  // A place for a breakpoint
 
         // Read Gyroscope data
         db_ism330_gyro_read(&gyro_data);
-        db_timer_hf_delay_ms(250);
+        db_timer_hf_delay_ms(0, 250);
         __NOP();  // A place for a breakpoint
     }
-
-    // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.
-    __NOP();
 }

--- a/projects/01drv_pid/01drv_pid.c
+++ b/projects/01drv_pid/01drv_pid.c
@@ -39,16 +39,11 @@ static const pid_gains_t _pid_params = {
     .kd = 0,
 };
 
-//=========================== prototypes =======================================
-
 //=========================== main =============================================
 
-/**
- *  @brief The program starts executing here.
- */
 int main(void) {
     // Initialize high frequency timer used to loop sample time delays
-    db_timer_hf_init();
+    db_timer_hf_init(0);
 
     // Turn ON the DotBot board regulator
     db_board_init();
@@ -82,11 +77,6 @@ int main(void) {
         puts("");
 
         db_motors_set_speed((int16_t)_pid_left.output, (int16_t)_pid_right.output);
-        db_timer_hf_delay_ms(PID_SAMPLE_TIME_MS);
+        db_timer_hf_delay_ms(0, PID_SAMPLE_TIME_MS);
     }
-
-    // one last instruction, doesn't do anything, it's just to have a place to put a breakpoint.
-    __NOP();
 }
-
-//=========================== functions ========================================

--- a/projects/03app_log_dump/main.c
+++ b/projects/03app_log_dump/main.c
@@ -31,7 +31,7 @@ static uint32_t *_read_address = (uint32_t *)(DB_LOG_FLASH_START + DB_FLASH_OFFS
 //=========================== main =============================================
 
 int main(void) {
-    db_timer_hf_init();
+    db_timer_hf_init(0);
 
     db_log_header_t header;
     db_nvmc_read(&header, _read_address++, sizeof(db_log_header_t));
@@ -66,7 +66,7 @@ int main(void) {
             goto loop;
     }
 
-    db_timer_hf_delay_ms(20);
+    db_timer_hf_delay_ms(0, 20);
     bool read = true;
     while (read) {
         switch (header.log_type) {
@@ -89,7 +89,7 @@ int main(void) {
                 _read_address += (sizeof(db_log_dotbot_data_t) >> 2);
             } break;
         }
-        db_timer_hf_delay_ms(20);
+        db_timer_hf_delay_ms(0, 20);
         read = ((uint32_t)_read_address < DB_FLASH_PAGE_NUM * DB_FLASH_PAGE_SIZE);
         if (!read) {
             puts("STOP (end of flash reached)");

--- a/projects/03app_xgo/main.c
+++ b/projects/03app_xgo/main.c
@@ -179,7 +179,7 @@ static void _action(xgo_action_id_t action_id) {
     _xgo_vars.action_running = true;
     _write(XGO_ADDRESS_ACTION_COMMAND, action_id);
     // Wait for the action to complete
-    db_timer_hf_delay_s(_action_execution_time_s[action_id]);
+    db_timer_hf_delay_s(0, _action_execution_time_s[action_id]);
     _xgo_vars.action_running = false;
 }
 
@@ -278,14 +278,14 @@ int main(void) {
 
     db_uart_init(0, &_uart_rx, &_uart_tx, XGO_UART_BAUDRATE, NULL);
 
-    db_timer_hf_init();
-    db_timer_hf_set_periodic_us(0, XGO_TIMEOUT_CHECK_DELAY_US, &_timeout_check);
-    db_timer_hf_set_periodic_us(1, XGO_ADVERTIZEMENT_DELAY_US, &_advertize);
+    db_timer_hf_init(0);
+    db_timer_hf_set_periodic_us(0, 0, XGO_TIMEOUT_CHECK_DELAY_US, &_timeout_check);
+    db_timer_hf_set_periodic_us(0, 1, XGO_ADVERTIZEMENT_DELAY_US, &_advertize);
 
     while (1) {
         __WFE();
         if (_xgo_vars.packet_received) {
-            _xgo_vars.ts_last_packet_received = db_timer_hf_now();
+            _xgo_vars.ts_last_packet_received = db_timer_hf_now(0);
             _xgo_vars.packet_received         = false;
         }
 
@@ -297,7 +297,7 @@ int main(void) {
         }
 
         if (_xgo_vars.timeout_check) {
-            uint32_t now = db_timer_hf_now();
+            uint32_t now = db_timer_hf_now(0);
             if (now > _xgo_vars.ts_last_packet_received + TIMEOUT_CHECK_DELAY_US) {
                 _action(XGO_ACTION_RESTORE);
             }


### PR DESCRIPTION
fixes #308 