### PR TITLE
lh2_mocap: Add mocap detection functions to the lh2 driver

### DIFF
--- a/bsp/lh2.h
+++ b/bsp/lh2.h
@@ -27,6 +27,9 @@
 #define LH2_POLYNOMIAL_COUNT  LH2_BASESTATION_COUNT * 2  ///< Number of supported LFSR polynomials, two per basestation
 #define LH2_SWEEP_COUNT       2                          ///< Number of laser sweeps per basestations rotation
 
+// Un-comment the following line if you want to enable the Anti-Mocap fiter
+// #define LH2_MOCAP_FILTER 1   ///< Defined when the LH2 needs to coexits with a Qualysis Mocap system. It enables harsher anti-outlier filters
+
 /// LH2 data ready buffer state
 typedef enum {
     DB_LH2_NO_NEW_DATA,               ///< The data occupying this spot of the buffer has already been sent.


### PR DESCRIPTION
 fixes #288 