### PR TITLE
nrf53: cleanup all trustzone rights given to network core peripherals

### DIFF
--- a/bsp/nrf/radio_nrf5340_app.c
+++ b/bsp/nrf/radio_nrf5340_app.c
@@ -32,18 +32,6 @@ extern volatile __attribute__((section(".shared_data"))) ipc_shared_data_t ipc_s
 void db_radio_init(radio_cb_t callback, db_radio_mode_t mode) {
     db_hfclk_init();
 
-    // Disable all DCDC regulators (use LDO)
-    NRF_REGULATORS_S->VREGRADIO.DCDCEN = (REGULATORS_VREGRADIO_DCDCEN_DCDCEN_Disabled << REGULATORS_VREGRADIO_DCDCEN_DCDCEN_Pos);
-    NRF_REGULATORS_S->VREGMAIN.DCDCEN  = (REGULATORS_VREGMAIN_DCDCEN_DCDCEN_Disabled << REGULATORS_VREGMAIN_DCDCEN_DCDCEN_Pos);
-    NRF_REGULATORS_S->VREGH.DCDCEN     = (REGULATORS_VREGH_DCDCEN_DCDCEN_Disabled << REGULATORS_VREGH_DCDCEN_DCDCEN_Pos);
-
-    // RADIO (address at 0x41008000 => periph ID is 8)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_RADIO);
-    db_tz_enable_network_periph_dma(NRF_NETWORK_PERIPH_ID_RADIO);
-
-    // IPC (address at 0x41012000 => periph ID is 18)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_IPC);
-
     // APPMUTEX (address at 0x41030000 => periph ID is 48)
     db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_APPMUTEX);
 

--- a/bsp/nrf/rng_nrf5340_app.c
+++ b/bsp/nrf/rng_nrf5340_app.c
@@ -23,14 +23,6 @@ extern volatile __attribute__((section(".shared_data"))) ipc_shared_data_t ipc_s
 //=========================== public ===========================================
 
 void db_rng_init(void) {
-    // RNG (address at 0x41009000 => periph ID is 9)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_RNG);
-
-    // IPC (address at 0x41012000 => periph ID is 18)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_IPC);
-
-    // APPMUTEX (address at 0x41030000 => periph ID is 48)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_APPMUTEX);
 
     // Define RAMREGION 2 (0x20004000 to 0x20005FFF, e.g 8KiB) as non secure. It's used to share data between cores
     db_configure_ram_non_secure(2, 1);

--- a/nRF/System/nRF5340_xxAA_Application_cpu.c
+++ b/nRF/System/nRF5340_xxAA_Application_cpu.c
@@ -101,7 +101,6 @@ void release_network_core(void) {
         ipc_shared_data.net_ready = false;
     }
 
-    NRF_POWER_S->TASKS_CONSTLAT   = 1;
     NRF_RESET_S->NETWORK.FORCEOFF = (RESET_NETWORK_FORCEOFF_FORCEOFF_Release << RESET_NETWORK_FORCEOFF_FORCEOFF_Pos);
 
     while (!ipc_shared_data.net_ready) {}

--- a/projects/03app_nrf5340_app/main.c
+++ b/projects/03app_nrf5340_app/main.c
@@ -16,46 +16,6 @@
 
 int main(void) {
 
-    // On nrf53 configure constant latency mode for better performances
-    NRF_POWER_S->TASKS_CONSTLAT = 1;
-
-    db_hfclk_init();
-    db_lfclk_init();
-
-    // Mark peripherals required by the network as non secure
-
-    // VREQCTRL (address at 0x41004000 => periph ID is 4)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_VREQCTRL);
-
-    // POWER (address at 0x41005000 => periph ID is 5)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_CLOCK_POWER_RESET);
-
-    // RADIO (address at 0x41008000 => periph ID is 8)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_RADIO);
-    db_tz_enable_network_periph_dma(NRF_NETWORK_PERIPH_ID_RADIO);
-
-    // RNG (address at 0x41009000 => periph ID is 9)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_RNG);
-
-    // TIMER0 (address at 0x4100C000 => periph ID is 12)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_TIMER0);
-
-    // UARTE0/TWIM0/SPIM0 (address at 0x41013000 => periph ID is 19)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_SPIM0_SPIS0_TWIM0_TWIS0_UARTE0);
-    db_tz_enable_network_periph_dma(NRF_NETWORK_PERIPH_ID_SPIM0_SPIS0_TWIM0_TWIS0_UARTE0);
-
-    // RTC1 (address at 0x41016000 => periph ID is 22)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_RTC1);
-
-    // TIMER1 (address at 0x41018000 => periph ID is 24)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_TIMER1);
-
-    // TIMER2 (address at 0x41019000 => periph ID is 25)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_TIMER2);
-
-    // WDT (address at 0x4100B000 => periph ID is 11)
-    db_tz_enable_network_periph(NRF_NETWORK_PERIPH_ID_WDT0);
-
     // Define FLASHREGION 62-63 as non secure (half of the network core flash)
     db_configure_flash_non_secure(62, 2);
 

--- a/projects/03app_nrf5340_net/main.c
+++ b/projects/03app_nrf5340_net/main.c
@@ -72,9 +72,6 @@ int main(void) {
     _nrf53_net_vars._data_received = false;
     _nrf53_net_vars._req_received  = DB_IPC_REQ_NONE;
 
-    // Configure constant latency mode for better performances
-    NRF_POWER_NS->TASKS_CONSTLAT = 1;
-
     NRF_IPC_NS->INTENSET                       = 1 << DB_IPC_CHAN_REQ;
     NRF_IPC_NS->SEND_CNF[DB_IPC_CHAN_RADIO_RX] = 1 << DB_IPC_CHAN_RADIO_RX;
     NRF_IPC_NS->RECEIVE_CNF[DB_IPC_CHAN_REQ]   = 1 << DB_IPC_CHAN_REQ;


### PR DESCRIPTION
depends on #335 and #334 