### PR TITLE
bsp: add support for non secure peripherals on application core

### DIFF
--- a/bsp/clock.h
+++ b/bsp/clock.h
@@ -14,10 +14,10 @@
  */
 
 #if defined(NRF5340_XXAA)
-#if defined(NRF_APPLICATION)
-#define NRF_CLOCK NRF_CLOCK_S
-#else
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
 #define NRF_CLOCK NRF_CLOCK_NS
+#else
+#define NRF_CLOCK NRF_CLOCK_S
 #endif
 #endif
 

--- a/bsp/gpio.h
+++ b/bsp/gpio.h
@@ -18,16 +18,24 @@
 
 //=========================== defines ==========================================
 
-#if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
+#if defined(NRF5340_XXAA)
+#if defined(NRF_NETWORK)
+#define NRF_P0     NRF_P0_NS
+#define NRF_P1     NRF_P1_NS
+#define NRF_GPIOTE NRF_GPIOTE_NS
+#elif defined(NRF_APPLICATION) && defined(NRF_TRUSTZONE_NONSECURE)
+#define NRF_P0            NRF_P0_NS
+#define NRF_P1            NRF_P1_NS
+#define NRF_GPIOTE        NRF_GPIOTE1_NS
+#define GPIOTE_IRQn       GPIOTE1_IRQn
+#define GPIOTE_IRQHandler GPIOTE1_IRQHandler
+#elif defined(NRF_APPLICATION)
 #define NRF_P0            NRF_P0_S
 #define NRF_P1            NRF_P1_S
 #define NRF_GPIOTE        NRF_GPIOTE0_S
 #define GPIOTE_IRQn       GPIOTE0_IRQn
 #define GPIOTE_IRQHandler GPIOTE0_IRQHandler
-#elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)
-#define NRF_P0     NRF_P0_NS
-#define NRF_P1     NRF_P1_NS
-#define NRF_GPIOTE NRF_GPIOTE_NS
+#endif
 #endif
 
 /**

--- a/bsp/nrf/i2c.c
+++ b/bsp/nrf/i2c.c
@@ -43,16 +43,20 @@ void _wait_for_transfer(i2c_t i2c);
 static const i2c_conf_t _devs[TWIM_COUNT] = {
 #if defined(NRF5340_XXAA)
     {
-#if defined(NRF_APPLICATION)
-        .p = NRF_TWIM0_S,
-#else
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
         .p = NRF_TWIM0_NS,
+#else
+        .p = NRF_TWIM0_S,
 #endif
         .irq = SERIAL0_IRQn,
     },
 #if defined(NRF_APPLICATION)
     {
-        .p   = NRF_TWIM1_S,
+#if defined(NRF_TRUSTZONE_NONSECURE)
+        .p = NRF_TWIM1_NS,
+#else
+        .p = NRF_TWIM1_S,
+#endif
         .irq = SERIAL1_IRQn,
     },
 #endif

--- a/bsp/nrf/lh2_default.c
+++ b/bsp/nrf/lh2_default.c
@@ -54,11 +54,17 @@
 #endif
 
 #if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
-#define NRF_SPIM         NRF_SPIM4_S
+#if defined(NRF_TRUSTZONE_NONSECURE)
+#define NRF_SPIM   NRF_SPIM4_NS
+#define NRF_GPIOTE NRF_GPIOTE0_NS
+#define NRF_PPI    NRF_DPPIC_NS
+#else
+#define NRF_SPIM   NRF_SPIM4_S
+#define NRF_GPIOTE NRF_GPIOTE0_S
+#define NRF_PPI    NRF_DPPIC_S
+#endif
 #define SPIM_IRQ         SPIM4_IRQn
 #define SPIM_IRQ_HANDLER SPIM4_IRQHandler
-#define NRF_GPIOTE       NRF_GPIOTE0_S
-#define NRF_PPI          NRF_DPPIC_S
 #else
 #define NRF_SPIM         NRF_SPIM3
 #define SPIM_IRQ         SPIM3_IRQn

--- a/bsp/nrf/nvmc.c
+++ b/bsp/nrf/nvmc.c
@@ -19,10 +19,12 @@
 
 //=========================== defines =========================================
 
-#if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
-#define NRF_NVMC NRF_NVMC_S
-#elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)
+#if defined(NRF5340_XXAA)
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
 #define NRF_NVMC NRF_NVMC_NS
+#elif defined(NRF_APPLICATION)
+#define NRF_NVMC NRF_NVMC_S
+#endif
 #endif
 
 //=========================== public ==========================================

--- a/bsp/nrf/partition.c
+++ b/bsp/nrf/partition.c
@@ -22,10 +22,12 @@
 
 //=========================== defines =========================================
 
-#if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
-#define NRF_NVMC NRF_NVMC_S
-#elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)
+#if defined(NRF5340_XXAA)
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
 #define NRF_NVMC NRF_NVMC_NS
+#elif defined(NRF_APPLICATION)
+#define NRF_NVMC NRF_NVMC_S
+#endif
 #endif
 
 #define DB_PARTITIONS_TABLE_ADDRESS (0x00001000UL + DB_FLASH_OFFSET)

--- a/bsp/nrf/pwm_default.c
+++ b/bsp/nrf/pwm_default.c
@@ -33,11 +33,18 @@ typedef struct {
 //=========================== variables ========================================
 
 static NRF_PWM_Type *_pwm_devs[PWM_COUNT] = {
-#if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
+#if defined(NRF5340_XXAA)
+#if defined(NRF_TRUSTZONE_NONSECURE)
+    NRF_PWM0_NS,
+    NRF_PWM1_NS,
+    NRF_PWM2_NS,
+    NRF_PWM3_NS,
+#else
     NRF_PWM0_S,
     NRF_PWM1_S,
     NRF_PWM2_S,
     NRF_PWM3_S,
+#endif
 #else
     NRF_PWM0,
     NRF_PWM1,

--- a/bsp/nrf/qdec.c
+++ b/bsp/nrf/qdec.c
@@ -26,8 +26,13 @@ typedef struct {
 
 static qdec_vars_t    _qdec_vars[QDEC_COUNT];
 static NRF_QDEC_Type *_qdec_devs[QDEC_COUNT] = {
+#if defined(NRF_TRUSTZONE_NONSECURE)
+    NRF_QDEC0_NS,
+    NRF_QDEC1_NS
+#else
     NRF_QDEC0_S,
     NRF_QDEC1_S
+#endif
 };
 
 //=========================== public ===========================================

--- a/bsp/nrf/qspi.c
+++ b/bsp/nrf/qspi.c
@@ -23,10 +23,10 @@
 //=========================== defines ==========================================
 
 #if defined(NRF5340_XXAA)
-#if defined(NRF_APPLICATION)
-#define DB_QSPI (NRF_QSPI_S)  ///< QSPI peripheral used
-#elif defined(NRF_NETWORK)
+#if defined(NRF_TRUSTZONE_NONSECURE)
 #define DB_QSPI (NRF_QSPI_NS)  ///< QSPI peripheral used
+#else
+#define DB_QSPI (NRF_QSPI_S)  ///< QSPI peripheral used
 #endif
 #else
 #define DB_QSPI (NRF_QSPI)  ///< QSPI peripheral

--- a/bsp/nrf/rpm.c
+++ b/bsp/nrf/rpm.c
@@ -19,15 +19,17 @@
 
 //=========================== defines ==========================================
 
-#if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
+#if defined(NRF5340_XXAA)
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
+#define NRF_TIMER0 NRF_TIMER0_NS
+#define NRF_TIMER1 NRF_TIMER1_NS
+#define NRF_PPI    NRF_DPPIC_NS
+#elif defined(NRF_APPLICATION)
 #define NRF_GPIOTE NRF_GPIOTE0_S
 #define NRF_TIMER0 NRF_TIMER0_S
 #define NRF_TIMER1 NRF_TIMER1_S
 #define NRF_PPI    NRF_DPPIC_S
-#elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)
-#define NRF_TIMER0 NRF_TIMER0_NS
-#define NRF_TIMER1 NRF_TIMER1_NS
-#define NRF_PPI    NRF_DPPIC_NS
+#endif
 #endif
 
 #define RPM_LEFT_TIMER        (NRF_TIMER0)  ///< Timer peripheral used to count left cycles

--- a/bsp/nrf/saadc.c
+++ b/bsp/nrf/saadc.c
@@ -18,10 +18,10 @@
 //=========================== defines ==========================================
 
 #if defined(NRF5340_XXAA)
-#if defined(NRF_APPLICATION)
-#define NRF_SAADC NRF_SAADC_S
-#else
+#if defined(NRF_TRUSTZONE_NONSECURE)
 #define NRF_SAADC NRF_SAADC_NS
+#else
+#define NRF_SAADC NRF_SAADC_S
 #endif
 #endif
 

--- a/bsp/nrf/spim.c
+++ b/bsp/nrf/spim.c
@@ -37,28 +37,44 @@ typedef struct {
 static const spim_conf_t _devs[SPIM_COUNT] = {
 #if defined(NRF5340_XXAA)
     {
-#if defined(NRF_APPLICATION)
-        .p = NRF_SPIM0_S,
-#else
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
         .p = NRF_SPIM0_NS,
+#else
+        .p = NRF_SPIM0_S,
 #endif
         .irq = SERIAL0_IRQn,
     },
 #if defined(NRF_APPLICATION)
     {
-        .p   = NRF_SPIM1_S,
+#if defined(NRF_TRUSTZONE_NONSECURE)
+        .p = NRF_SPIM1_NS,
+#else
+        .p = NRF_SPIM1_S,
+#endif
         .irq = SERIAL1_IRQn,
     },
     {
-        .p   = NRF_SPIM2_S,
+#if defined(NRF_TRUSTZONE_NONSECURE)
+        .p = NRF_SPIM2_NS,
+#else
+        .p = NRF_SPIM2_S,
+#endif
         .irq = SERIAL2_IRQn,
     },
     {
-        .p   = NRF_SPIM3_S,
+#if defined(NRF_TRUSTZONE_NONSECURE)
+        .p = NRF_SPIM3_NS,
+#else
+        .p = NRF_SPIM3_S,
+#endif
         .irq = SERIAL3_IRQn,
     },
     {
-        .p   = NRF_SPIM4_S,
+#if defined(NRF_TRUSTZONE_NONSECURE)
+        .p = NRF_SPIM4_NS,
+#else
+        .p = NRF_SPIM4_S,
+#endif
         .irq = SPIM4_IRQn,
     },
 #endif

--- a/bsp/nrf/timer.c
+++ b/bsp/nrf/timer.c
@@ -46,19 +46,19 @@ static uint32_t _ms_to_ticks(uint32_t ms);
 static const timer_conf_t _devs[RTC_COUNT] = {
 #if defined(NRF5340_XXAA)
     {
-#if defined(NRF_APPLICATION)
-        .p = NRF_RTC0_S,
-#else
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
         .p = NRF_RTC0_NS,
+#else
+        .p = NRF_RTC0_S,
 #endif
         .irq    = RTC0_IRQn,
         .cc_num = RTC0_CC_NUM - 1,
     },
     {
-#if defined(NRF_APPLICATION)
-        .p = NRF_RTC1_S,
-#else
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
         .p = NRF_RTC1_NS,
+#else
+        .p = NRF_RTC1_S,
 #endif
         .irq    = RTC1_IRQn,
         .cc_num = RTC1_CC_NUM - 1,
@@ -90,8 +90,10 @@ void db_timer_init(timer_t timer) {
     // No delay is running after initialization
     _timer_vars[timer].running = false;
 
+#if !defined(USE_SWARMIT)
     // Configure and start Low Frequency clock
     db_lfclk_init();
+#endif
 
     // Configure the RTC
     _devs[timer].p->TASKS_STOP  = 1;

--- a/bsp/nrf/timer_hf.c
+++ b/bsp/nrf/timer_hf.c
@@ -42,7 +42,7 @@ typedef struct {
 static const timer_hf_conf_t _devs[TIMER_COUNT] = {
 #if defined(NRF5340_XXAA)
     {
-#if defined(NRF_NETWORK)
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
         .p = NRF_TIMER0_NS,
 #else
         .p = NRF_TIMER0_S,
@@ -51,7 +51,7 @@ static const timer_hf_conf_t _devs[TIMER_COUNT] = {
         .cc_num = TIMER0_CC_NUM - 1,
     },
     {
-#if defined(NRF_NETWORK)
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
         .p = NRF_TIMER1_NS,
 #else
         .p = NRF_TIMER1_S,
@@ -60,7 +60,7 @@ static const timer_hf_conf_t _devs[TIMER_COUNT] = {
         .cc_num = TIMER1_CC_NUM - 1,
     },
     {
-#if defined(NRF_NETWORK)
+#if defined(NRF_NETWORK) || defined(NRF_TRUSTZONE_NONSECURE)
         .p = NRF_TIMER2_NS,
 #else
         .p = NRF_TIMER2_S,
@@ -105,8 +105,10 @@ void db_timer_hf_init(timer_hf_t timer) {
     // No delay is running after initialization
     _timer_hf_vars[timer].running = false;
 
+#if !defined(USE_SWARMIT)
     // Configure and start High Frequency clock
     db_hfclk_init();
+#endif
 
     // Configure the timer
     _devs[timer].p->TASKS_CLEAR = 1;

--- a/bsp/nrf/uart.c
+++ b/bsp/nrf/uart.c
@@ -41,19 +41,35 @@ typedef struct {
 static const uart_conf_t _devs[UARTE_COUNT] = {
 #if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
     {
-        .p   = NRF_UARTE0_S,
+#if defined(NRF_TRUSTZONE_NONSECURE)
+        .p = NRF_UARTE0_NS,
+#else
+        .p = NRF_UARTE0_S,
+#endif
         .irq = SERIAL0_IRQn,
     },
     {
-        .p   = NRF_UARTE1_S,
+#if defined(NRF_TRUSTZONE_NONSECURE)
+        .p = NRF_UARTE1_NS,
+#else
+        .p = NRF_UARTE1_S,
+#endif
         .irq = SERIAL1_IRQn,
     },
     {
-        .p   = NRF_UARTE2_S,
+#if defined(NRF_TRUSTZONE_NONSECURE)
+        .p = NRF_UARTE2_NS,
+#else
+        .p = NRF_UARTE2_S,
+#endif
         .irq = SERIAL2_IRQn,
     },
     {
-        .p   = NRF_UARTE3_S,
+#if defined(NRF_TRUSTZONE_NONSECURE)
+        .p = NRF_UARTE3_NS,
+#else
+        .p = NRF_UARTE3_S,
+#endif
         .irq = SERIAL3_IRQn,
     },
 #elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)

--- a/bsp/nrf/wdt.c
+++ b/bsp/nrf/wdt.c
@@ -15,7 +15,11 @@
 
 #if defined(NRF5340_XXAA)
 #if defined(NRF_APPLICATION)
-#define NRF_WDT        NRF_WDT0_S
+#if defined(NRF_TRUSTZONE_NONSECURE)
+#define NRF_WDT NRF_WDT0_NS
+#else
+#define NRF_WDT NRF_WDT0_S
+#endif
 #define WDT_IRQn       WDT0_IRQn
 #define WDT_IRQHandler WDT0_IRQHandler
 #elif defined(NRF_NETWORK)

--- a/nRF/System/cpu.c
+++ b/nRF/System/cpu.c
@@ -160,7 +160,7 @@ void reset_handler(void) {
         func++();
     }
 
-#ifndef __NO_SYSTEM_INIT
+#if !defined(__NO_SYSTEM_INIT) && !defined(NRF_TRUSTZONE_NONSECURE)
     system_init();
 #endif
 


### PR DESCRIPTION
This PR is useful for building dotbot-firmware based application compatible with [swarmit](https://github.com/DotBots/swarmit).
Just add `NRF_TRUSTZONE_NONSECURE` CFLAGS to the build project.

depends on #334, #335 and #336 