### PR TITLE
IEEE 802.15.4 PHY: changes on CRC handling to make it protocol compliant

### DIFF
--- a/bsp/nrf/radio_default.c
+++ b/bsp/nrf/radio_default.c
@@ -184,13 +184,14 @@ void db_radio_init(radio_cb_t callback, db_radio_mode_t mode) {
     // CRC Config
     if (mode == DB_RADIO_IEEE802154_250Kbit) {
         NRF_RADIO->CRCCNF = (RADIO_CRCCNF_LEN_Two << RADIO_CRCCNF_LEN_Pos) |                  // 16-bit (2 bytes) CRC
-                            (RADIO_CRCCNF_SKIPADDR_Ieee802154 << RADIO_CRCCNF_SKIPADDR_Pos);  // CRCCNF = 0x202 for IEEE 802.15.4
-        NRF_RADIO->CRCINIT = 0;                                                               // The start value used by IEEE 802.15.4 is zero
-        NRF_RADIO->CRCPOLY = 0x11021;
+                            (RADIO_CRCCNF_SKIPADDR_Ieee802154 << RADIO_CRCCNF_SKIPADDR_Pos);  // CRCCNF = 0x202
+        NRF_RADIO->CRCINIT = 0x0000;                                                          // Initial CRC is zero for IEEE 802.15.4
+        NRF_RADIO->CRCPOLY = 0x011021;                                                        // CRC poly: x¹⁶ + x¹² + x⁵ + 1
     } else {
-        NRF_RADIO->CRCCNF  = (RADIO_CRCCNF_LEN_Three << RADIO_CRCCNF_LEN_Pos) | (RADIO_CRCCNF_SKIPADDR_Skip << RADIO_CRCCNF_SKIPADDR_Pos);  // Checksum uses 3 bytes, and is enabled.
-        NRF_RADIO->CRCINIT = 0xFFFFUL;                                                                                                      // initial value
-        NRF_RADIO->CRCPOLY = 0x00065b;                                                                                                      // CRC poly: x^16 + x^12^x^5 + 1
+        NRF_RADIO->CRCCNF = (RADIO_CRCCNF_LEN_Three << RADIO_CRCCNF_LEN_Pos) |  // Checksum uses 3 bytes, and is enabled
+                            (RADIO_CRCCNF_SKIPADDR_Skip << RADIO_CRCCNF_SKIPADDR_Pos);
+        NRF_RADIO->CRCINIT = 0x00FFFF;  // Initial CRC value
+        NRF_RADIO->CRCPOLY = 0x00065b;  // CRC poly: x¹⁰ + x⁹ + x⁶ + x⁴ + x³ + x + 1
     }
 
     // Configure pointer to PDU for EasyDMA

--- a/bsp/nrf/radio_default.c
+++ b/bsp/nrf/radio_default.c
@@ -121,11 +121,11 @@ void db_radio_init(radio_cb_t callback, db_radio_mode_t mode) {
         NRF_RADIO->TXPOWER = (RADIO_TXPOWER_TXPOWER_0dBm << RADIO_TXPOWER_TXPOWER_Pos);  // Set transmission power to 0dBm
 
         // Packet configuration register 0
-        NRF_RADIO->PCNF0 = (0 << RADIO_PCNF0_S1LEN_Pos) |                          // S1 field length in bits
-                           (0 << RADIO_PCNF0_S0LEN_Pos) |                          // S0 field length in bytes
-                           (8 << RADIO_PCNF0_LFLEN_Pos) |                          // 8-bit length field
-                           (RADIO_PCNF0_PLEN_32bitZero << RADIO_PCNF0_PLEN_Pos) |  // 4 bytes that are all zero for IEEE 802.15.4
-                           (RADIO_PCNF0_CRCINC_Exclude << RADIO_PCNF0_CRCINC_Pos);
+        NRF_RADIO->PCNF0 = (0 << RADIO_PCNF0_S1LEN_Pos) |                           // S1 field length in bits
+                           (0 << RADIO_PCNF0_S0LEN_Pos) |                           // S0 field length in bytes
+                           (8 << RADIO_PCNF0_LFLEN_Pos) |                           // 8-bit length field
+                           (RADIO_PCNF0_PLEN_32bitZero << RADIO_PCNF0_PLEN_Pos) |   // 4 bytes that are all zero for IEEE 802.15.4
+                           (RADIO_PCNF0_CRCINC_Include << RADIO_PCNF0_CRCINC_Pos);  // Length field includes CRC (length = 127 -> 125B payload, 2B CRC)
 
         // // Packet configuration register 1
         NRF_RADIO->PCNF1 = (DB_IEEE802154_PAYLOAD_MAX_LENGTH << RADIO_PCNF1_MAXLEN_Pos) |  // Max payload of 127 bytes (including CRC)

--- a/bsp/radio.h
+++ b/bsp/radio.h
@@ -29,7 +29,7 @@
 #endif
 
 #define DB_BLE_PAYLOAD_MAX_LENGTH        UINT8_MAX
-#define DB_IEEE802154_PAYLOAD_MAX_LENGTH (125UL)  ///< Total usable payload for IEEE 802.15.4 is 125 octets (PSDU) when CRC is activated
+#define DB_IEEE802154_PAYLOAD_MAX_LENGTH (127UL)  ///< Total usable payload for IEEE 802.15.4 is 125 octets (PSDU) when CRC is activated
 
 /// Modes supported by the radio
 typedef enum {

--- a/projects/01bsp_radio_txrx/01bsp_radio_txrx.c
+++ b/projects/01bsp_radio_txrx/01bsp_radio_txrx.c
@@ -41,8 +41,12 @@ static const uint8_t packet_tx[] = {
     0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,  // AAAAAAAA
     0x2D, 0x2D, 0x2D, 0x2D, 0x2D, 0x2D, 0x2D, 0x2D,  // --------
     0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,  // AAAAAAAA
-    0x31, 0x32, 0x33, 0x34, 0x00,                    // 1234 + null
-};
+    0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x00         // 123456 + null
+};  // 127 Bytes long.
+
+// For IEEE 802.15.4, the last two bytes, 0x36 and 0x00 are discarded to place the CRC.
+// The output print being wrong for the last two bytes is expected, and has to be accounted for when enabling CRC.
+// The CRC is not loaded into RAM as part of the packet and checked directly in the radio peripheral.
 
 static const gpio_t _dbg_pin = { .port = DB_LED1_PORT, .pin = DB_LED1_PIN };
 


### PR DESCRIPTION
### Before  

When `NRF_RADIO->PCNF0 |= (RADIO_PCNF0_CRCINC_Exclude << RADIO_PCNF0_CRCINC_Pos)`, meaning the CRC is not included in the payload, communication between nRF devices works correctly with CRC checking. Each nRF device expects the two bytes following the payload to be the CRC.  

However, when communicating with other IEEE 802.15.4 PHY-compliant devices, the physical layer only reads the total number of bytes specified by the length field. It does not check the CRC correctly or may mistakenly use the last two bytes of the payload as the CRC instead of the actual CRC bytes.  

For example, when transmitting the packet `{ 0x31, 0x32, 0x33 }` (with `length = 3` bytes), the actual transmitted data is:  
```
Payload: [0x31, 0x32, 0x33]
CRC: [0x78, 0x5a]
Total: 5 bytes (but frame length = 3)
```


This behaviour is similar to how BLE works, where the usable payload size equals the frame length field, and the 3-byte CRC is appended afterward.  

### After  

Making `NRF_RADIO->PCNF0 |= (RADIO_PCNF0_CRCINC_Include << RADIO_PCNF0_CRCINC_Pos)`, the CRC is included in the payload count.  

For example, when transmitting the packet `{ 0x31, 0x32, 0x33, 0x34, 0x35 }` (with `frame length = 5` bytes), the CRC is appended after  `frame length - 2`, and the last two bytes are then discarded. The actual transmitted data (sniffed with a Software Defined Radio) is:  

```
Payload: [0x31, 0x32, 0x33, 0x78, 0x5a]
Total: 5 bytes (and frame length = 5)
(Last two bytes are discarded in transmission and replaced by the CRC)
```

When sending packets, it is important to account for this  discarding of the last two bytes if CRC is enabled.  