### PR TITLE
bsp/nrf/timer: set lower priority to timers

### DIFF
--- a/bsp/nrf/timer.c
+++ b/bsp/nrf/timer.c
@@ -20,6 +20,7 @@
 //=========================== define ===========================================
 
 #define TIMER_MAX_CHANNELS (4U)
+#define TIMER_IRQ_PRIORITY (3U)
 
 typedef struct {
     NRF_RTC_Type *p;
@@ -102,6 +103,7 @@ void db_timer_init(timer_t timer) {
     _devs[timer].p->PRESCALER   = 0;  // Run RTC at 32768Hz
     _devs[timer].p->INTENSET    = (1 << (RTC_INTENSET_COMPARE0_Pos + _devs[timer].cc_num));
     NVIC_EnableIRQ(_devs[timer].irq);
+    NVIC_SetPriority(_devs[timer].irq, TIMER_IRQ_PRIORITY);
 
     // Start the timer
     _devs[timer].p->TASKS_START = 1;

--- a/bsp/nrf/timer_hf.c
+++ b/bsp/nrf/timer_hf.c
@@ -19,6 +19,7 @@
 //=========================== define ===========================================
 
 #define TIMER_MAX_CHANNELS (6U)
+#define TIMER_IRQ_PRIORITY (2U)
 
 typedef struct {
     NRF_TIMER_Type *p;
@@ -115,6 +116,7 @@ void db_timer_hf_init(timer_hf_t timer) {
     _devs[timer].p->PRESCALER   = 4;  // Run TIMER at 1MHz
     _devs[timer].p->BITMODE     = (TIMER_BITMODE_BITMODE_32Bit << TIMER_BITMODE_BITMODE_Pos);
     _devs[timer].p->INTENSET    = (1 << (TIMER_INTENSET_COMPARE0_Pos + _devs[timer].cc_num));
+    NVIC_SetPriority(_devs[timer].irq, TIMER_IRQ_PRIORITY);
     NVIC_EnableIRQ(_devs[timer].irq);
 
     // Start the timer


### PR DESCRIPTION
This  improves a lot the reliability of the UART to radio gateways when timers are used with time slotted network stacks (TDMA, mira)