### PR TITLE
bsp/uart: fix bug when sending buffer larger than 192B

### DIFF
--- a/bsp/nrf/uart.c
+++ b/bsp/nrf/uart.c
@@ -202,9 +202,9 @@ void db_uart_init(uart_t uart, const gpio_t *rx_pin, const gpio_t *tx_pin, uint3
 }
 
 void db_uart_write(uart_t uart, uint8_t *buffer, size_t length) {
-    uint8_t pos = 0;
+    uint16_t pos = 0;
     // Send DB_UARTE_CHUNK_SIZE (64 Bytes) maximum at a time
-    while ((pos % DB_UARTE_CHUNK_SIZE) == 0 && pos < length) {
+    while (pos < length) {
         _devs[uart].p->EVENTS_ENDTX = 0;
         _devs[uart].p->TXD.PTR      = (uint32_t)&buffer[pos];
         if ((pos + DB_UARTE_CHUNK_SIZE) > length) {


### PR DESCRIPTION
The `pos` variable must be a 16bit integer otherwise it overflows it the length is > 192 bytes and the send function ends up in an infinite loop.