### PR TITLE
cmake: add opt-in CMake build path with cmake_hello demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# DotBot-firmware
+
+## Purpose
+
+Firmware applications for DotBot, SailBot, FreeBot, XGo, lh2-mini-mote micro-robots, and nRF gateway DKs. Pure consumer of `DotBot-libs` (via git submodule) — pulls in drivers/BSP and produces per-target ELF/HEX artifacts. The recent commit history is dominated by "bump dotbot-libs to latest", which is a strong signal that this repo and `DotBot-libs` are conceptually one thing.
+
+## Tech stack
+
+- **Languages**: C (firmware), Python + Sphinx for docs
+- **Targets**: Nordic nRF52833 / nRF52840 / nRF5340
+- **Build**: SEGGER Embedded Studio (`emBuild`) from a top-level `Makefile`; Docker wrapper (`aabadie/dotbot:latest`) for reproducible CI builds. Per-board `.emProject` files at the repo root.
+- **Style**: `clang-format`
+
+## Submodules
+
+This repo has **one** git submodule. After cloning, init it:
+
+```bash
+git clone --recurse-submodules https://github.com/DotBots/DotBot-firmware
+# or, if already cloned:
+git submodule update --init --recursive
+```
+
+| Submodule | Path | Pinned (snapshot 2026-05-12) |
+|---|---|---|
+| `DotBot-libs` | `dotbot-libs/` | `0.1.0-46-g1ebdd59` |
+
+Recent commit history is dominated by "bump dotbot-libs to latest", so this submodule is intentionally kept current with `DotBot-libs/main`. `dotbot-lh2-calibration` pins the same SHA; `swarmit` lags 41 commits behind.
+
+## Entry points
+
+- `README.md` — submodule clone instructions, SEGGER setup
+- `Makefile` — per-target project filtering, docker entry, format/doc targets
+- `projects/dotbot/main.c` — flagship app showing how BSP/libs from `DotBot-libs` are wired together
+
+## Build / run / test
+
+```bash
+git clone --recurse-submodules https://github.com/DotBots/DotBot-firmware
+make BUILD_TARGET=dotbot-v2 BUILD_CONFIG=Release          # host SES
+BUILD_TARGET=dotbot-v2 BUILD_CONFIG=Release make docker   # CI path
+make artifacts                                             # collect ELF/HEX
+make format / make check-format
+make doc                                                   # Sphinx doc/sphinx/
+```
+
+CI: `.github/workflows/build.yml` — matrix over 12 targets × {Debug, Release}, plus `style`, `doc`, tag-triggered `release`. **No tests** (CI is build-only).
+
+## Cross-repo dependencies
+
+- **`DotBot-libs`** — git submodule at `dotbot-libs/`. Single hard dependency. `main.c` headers (`lh2.h`, `protocol.h`, `motors.h`, `tdma_client.h`, `control_loop.h`, etc.) all resolve into it.
+- **`PyDotBot`** — referenced only as a runtime companion in READMEs and `doc/sphinx/conf.py` (no code dep)
+- **`swarmit`** — only on the dead `adapt_to_swarmit` branch; not on `main`
+- No references to: `mari`, `marilib`, `PyDotBot-utils`, `dotbot-lh2-calibration`, `dotbot-provision`, `qrkey`
+
+## State of repo (snapshot 2026-05-05)
+
+- Last commit on `main`: 2026-04-29
+- Total commits on `main`: 1576 (large repo)
+- Commits in last 90 days: 22 (last 365 days: 126). Actively maintained, primarily by `aabadie`.
+- Branches (4 stale remote):
+  - `171-integrate-ekf-into-the-dotbot-firmware` — 2022/2023 era, 1486 behind. Dead.
+  - `32-implement-ultrasound-ranging-01bsp_us_ranging` — 2022 era. Dead.
+  - `34-Implement-the-app-for-Ultrasound-ranging-...` — 2022 era. Dead.
+  - `adapt_to_swarmit` — last 2025-03-21, 130 behind. Possibly salvageable if swarmit integration moves forward.
+- TODO/FIXME/XXX/HACK: 0 in C/H/PY sources
+
+## Hot spots and known gaps
+
+- **Tight coupling to `DotBot-libs`**: this repo is essentially "apps for DotBot-libs". The two are strong consolidation candidates (see top-level AGENTS.md).
+- **SES license-gated build**: Docker image build commented out in CI. Biggest onboarding friction post-summer-2026.
+- **No tests at all** — CI only verifies it compiles.
+- **4 stale remote branches**, 3 from 2022 should be pruned. `adapt_to_swarmit` worth investigating.
+
+## Branch policy
+
+- Default: `main`
+- Three 2022-era branches (`171-...`, `32-...`, `34-...`) are dead. Safe to delete.
+- `adapt_to_swarmit` — investigate before deleting; may carry useful integration work.
+
+## Agent-task ideas
+
+- **Host-side unit tests** for protocol/state-machine code that's separable from HAL.
+- **SES → CMake/GCC migration** for at least one target. Highest-value onboarding unblock.
+- **Delete dead 2022-era branches** (`171-...`, `32-...`, `34-...`).
+- **Investigate `adapt_to_swarmit`**: rebase or delete.
+- **Reconcile `Makefile` project list** with `DotBot-libs/Makefile` (the `03app_*` projects in `DotBot-libs/Makefile` actually live here).
+- **Document board variants** — what's a DotBot-v2 vs v3 vs SailBot vs XGo at the firmware level (board init differences, motor wiring).
+
+## Don't
+
+- **Don't break the SES build** until a CMake/GCC equivalent is validated for at least one target.
+- **Don't bump `DotBot-libs` submodule** without verifying it builds for *all* matrix targets — main.c uses headers from many drivers.
+- **Don't merge `adapt_to_swarmit`** without coordinating with `swarmit` (the integration touches both).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,106 @@
+# DotBot-firmware — opt-in CMake build (additive, SES projects unchanged).
+#
+# Quick start:
+#
+#   # Use the bundled dotbot-libs submodule (default — what CI does):
+#   cmake -B build -DCMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi.cmake -G Ninja
+#   cmake --build build
+#
+#   # Use a local dotbot-libs checkout (typical dev-time workflow when
+#   # iterating on both repos simultaneously):
+#   cmake -B build -DCMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi.cmake \
+#         -DDOTBOT_LIBS=/path/to/local/DotBot-libs -G Ninja
+#
+# This file is ADDITIVE: existing SES (.emProject) projects under
+# projects/ continue to work unchanged. Only apps that have their own
+# CMakeLists.txt get added below.
+
+cmake_minimum_required(VERSION 3.20)
+
+project(dotbot-firmware
+    LANGUAGES C ASM
+    VERSION 0.0.1
+)
+
+# Emit build/compile_commands.json for clangd / IDE tooling.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Cortex-M33 hard-float flags shared by every nRF5340 app-core target.
+# Other chips (nRF52840/nRF52833 → Cortex-M4) will need different flags
+# when their support is added.
+set(CPU_FLAGS
+    -mcpu=cortex-m33
+    -mthumb
+    -mfloat-abi=hard
+    -mfpu=fpv5-sp-d16
+)
+
+set(COMMON_FLAGS
+    ${CPU_FLAGS}
+    -ffunction-sections
+    -fdata-sections
+    -Wall
+    -Wextra
+    -Wpedantic
+    # Silence dotbot-libs's nRF/System/*_cpu.c weak-alias declarations not
+    # matching dummy_handler's inferred `noreturn`. Upstream fix tracked
+    # separately. The -Wpointer-arith warning in cpu.c's ctor loop is
+    # NOT silenced — it's a real (latent) bug to fix upstream too.
+    -Wno-missing-attributes
+    -O0
+    -g3
+)
+
+add_compile_options(${COMMON_FLAGS})
+add_link_options(
+    ${CPU_FLAGS}
+    -Wl,--gc-sections
+    -Wl,--print-memory-usage
+    --specs=nosys.specs   # bare-metal: no syscalls
+    -nostartfiles         # cmake/targets/*/startup.S provides Reset_Handler
+)
+
+# ── Nordic MDK + ARM CMSIS-Core via FetchContent ─────────────────────
+# dotbot-libs sources #include <nrf.h> but don't ship device headers.
+# These FetchContent declarations satisfy that requirement.
+include(FetchContent)
+
+FetchContent_Declare(nrfx
+    GIT_REPOSITORY https://github.com/NordicSemiconductor/nrfx.git
+    GIT_TAG        v3.5.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_Declare(cmsis_core
+    GIT_REPOSITORY https://github.com/ARM-software/CMSIS_5.git
+    GIT_TAG        5.9.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(nrfx cmsis_core)
+
+set(NRFX_MDK_INCLUDE   ${nrfx_SOURCE_DIR}/mdk                       CACHE INTERNAL "Nordic MDK headers")
+set(CMSIS_CORE_INCLUDE ${cmsis_core_SOURCE_DIR}/CMSIS/Core/Include  CACHE INTERNAL "ARM CMSIS-Core headers")
+
+# ── dotbot-libs ──────────────────────────────────────────────────────
+# Default: the bundled git submodule (what CI / fresh-clone sees). For
+# day-to-day dev, override with -DDOTBOT_LIBS=/path/to/local/checkout
+# so you can iterate on both repos without committing+pushing
+# dotbot-libs every change.
+set(DOTBOT_LIBS "${CMAKE_CURRENT_SOURCE_DIR}/dotbot-libs"
+    CACHE PATH "Path to dotbot-libs. Defaults to the bundled submodule.")
+
+if(NOT EXISTS "${DOTBOT_LIBS}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "DOTBOT_LIBS=${DOTBOT_LIBS} has no CMakeLists.txt. "
+        "Either initialize the bundled submodule "
+        "(git submodule update --init --recursive) or override "
+        "-DDOTBOT_LIBS=/path/to/your/DotBot-libs checkout.")
+endif()
+
+add_subdirectory(${DOTBOT_LIBS} dotbot-libs-build EXCLUDE_FROM_ALL)
+
+# ── Apps ─────────────────────────────────────────────────────────────
+# Each app under projects/ that has its own CMakeLists.txt is listed
+# here. Apps without one are still buildable via their existing
+# .emProject files in SES.
+
+add_subdirectory(projects/cmake_hello)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,27 +60,10 @@ add_link_options(
     -nostartfiles         # cmake/targets/*/startup.S provides Reset_Handler
 )
 
-# ── Nordic MDK + ARM CMSIS-Core via FetchContent ─────────────────────
-# dotbot-libs sources #include <nrf.h> but don't ship device headers.
-# These FetchContent declarations satisfy that requirement.
-include(FetchContent)
-
-FetchContent_Declare(nrfx
-    GIT_REPOSITORY https://github.com/NordicSemiconductor/nrfx.git
-    GIT_TAG        v3.5.0
-    GIT_SHALLOW    TRUE
-)
-FetchContent_Declare(cmsis_core
-    GIT_REPOSITORY https://github.com/ARM-software/CMSIS_5.git
-    GIT_TAG        5.9.0
-    GIT_SHALLOW    TRUE
-)
-FetchContent_MakeAvailable(nrfx cmsis_core)
-
-set(NRFX_MDK_INCLUDE   ${nrfx_SOURCE_DIR}/mdk                       CACHE INTERNAL "Nordic MDK headers")
-set(CMSIS_CORE_INCLUDE ${cmsis_core_SOURCE_DIR}/CMSIS/Core/Include  CACHE INTERNAL "ARM CMSIS-Core headers")
-
-# ── dotbot-libs ──────────────────────────────────────────────────────
+# ── dotbot-libs (owns Nordic + CMSIS FetchContent) ───────────────────
+# Linking `dotbot_libs` (per-app, below) brings in the Nordic MDK
+# (nrf.h) and ARM CMSIS-Core (core_cm33.h) headers transitively via
+# the dotbot_nordic INTERFACE exported from dotbot-libs/CMakeLists.txt.
 # Default: the bundled git submodule (what CI / fresh-clone sees). For
 # day-to-day dev, override with -DDOTBOT_LIBS=/path/to/local/checkout
 # so you can iterate on both repos without committing+pushing

--- a/cmake/arm-none-eabi.cmake
+++ b/cmake/arm-none-eabi.cmake
@@ -1,0 +1,20 @@
+# gcc-arm-none-eabi toolchain file for DotBot-firmware CMake builds.
+#
+# Usage:
+#   cmake -B build -DCMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi.cmake -G Ninja
+
+set(CMAKE_SYSTEM_NAME      Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# Pre-empt CMake's compiler check, which would try to link a host binary.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# Toolchain executables. Override on the command line with
+#   -DARM_TOOLCHAIN_PREFIX=/path/to/bin/arm-none-eabi-
+# if Homebrew / your installer puts them somewhere CMake can't find.
+set(ARM_TOOLCHAIN_PREFIX "arm-none-eabi-" CACHE STRING "Toolchain command prefix")
+set(CMAKE_C_COMPILER   ${ARM_TOOLCHAIN_PREFIX}gcc)
+set(CMAKE_ASM_COMPILER ${ARM_TOOLCHAIN_PREFIX}gcc)
+set(CMAKE_CXX_COMPILER ${ARM_TOOLCHAIN_PREFIX}g++)
+set(CMAKE_OBJCOPY      ${ARM_TOOLCHAIN_PREFIX}objcopy CACHE INTERNAL "")
+set(CMAKE_SIZE         ${ARM_TOOLCHAIN_PREFIX}size    CACHE INTERNAL "")

--- a/cmake/targets/nrf5340-app/nrf5340_app.ld
+++ b/cmake/targets/nrf5340-app/nrf5340_app.ld
@@ -1,0 +1,195 @@
+/*
+ * GNU ld linker script for nRF5340 application core, secure mode.
+ *
+ * Translates dotbot-libs's SES flash placement (nRF/Setup/
+ * nRF5340_xxAA_Application_flash_placement.xml + MemoryMap.xml) to
+ * GNU ld syntax. Defines exactly the symbols dotbot-libs's pure-C
+ * startup (nRF/System/cpu.c + per-chip cpu.c) expects.
+ *
+ * Memory map (per SES MemoryMap.xml):
+ *   FLASH1  0x00000000  1024 KiB
+ *   RAM1    0x20000000   256 KiB    ← we use this one
+ *   RAM2    0x20040000   252 KiB    ← left unused for now
+ *
+ * Pinned section: .shared_data at 0x20004000 (16 KiB into RAM1) —
+ * the TrustZone IPC region nRF5340_xxAA_Application_cpu.c's
+ * ipc_shared_data symbol lives in. Stack: 8 KiB at top of RAM1.
+ */
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 1024K
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+ENTRY(reset_handler)
+
+__STACKSIZE__         = 8K;
+__STACKSIZE_PROCESS__ = 0;
+__HEAPSIZE__          = 0;
+
+/* Pinned address for the TrustZone IPC shared-data region. cpu.c
+ * places `ipc_shared_data` here so secure + non-secure sides agree. */
+__shared_data_addr__  = 0x20004000;
+
+SECTIONS
+{
+    /* ── FLASH ─────────────────────────────────────────────────── */
+
+    .vectors :
+    {
+        KEEP(*(.vectors))
+        KEEP(*(.isr_vector))   /* legacy / Nordic naming, just in case */
+    } > FLASH
+
+    .text :
+    {
+        *(.text*)
+        *(.init)
+        *(.init_rodata)
+        . = ALIGN(4);
+    } > FLASH
+
+    .rodata :
+    {
+        *(.rodata*)
+        . = ALIGN(4);
+    } > FLASH
+
+    /* ── Initialized data: copied flash → RAM by reset_handler ──── */
+
+    .data :
+    {
+        . = ALIGN(4);
+        __data_start__ = .;
+        *(.data*)
+        *(.data_run)
+        . = ALIGN(4);
+        __data_end__ = .;
+    } > RAM AT > FLASH
+    __data_load_start__ = LOADADDR(.data);
+
+    .fast :
+    {
+        . = ALIGN(4);
+        __fast_start__ = .;
+        *(.fast*)
+        *(.fast_run)
+        . = ALIGN(4);
+        __fast_end__ = .;
+    } > RAM AT > FLASH
+    __fast_load_start__ = LOADADDR(.fast);
+
+    .ctors :
+    {
+        . = ALIGN(4);
+        __ctors_start__ = .;
+        KEEP(*(SORT(.ctors.*)))
+        KEEP(*(.ctors))
+        __ctors_end__ = .;
+    } > RAM AT > FLASH
+    __ctors_load_start__ = LOADADDR(.ctors);
+
+    .dtors :
+    {
+        . = ALIGN(4);
+        __dtors_start__ = .;
+        KEEP(*(SORT(.dtors.*)))
+        KEEP(*(.dtors))
+        __dtors_end__ = .;
+    } > RAM AT > FLASH
+    __dtors_load_start__ = LOADADDR(.dtors);
+
+    /* .rodata copy-to-RAM only happens under DEBUG; emit placeholder
+     * symbols at the same address so cpu.c's load-check `if (dst == src)`
+     * trips and the copy is skipped. */
+    __rodata_start__       = .;
+    __rodata_end__         = .;
+    __rodata_load_start__  = .;
+
+    .tdata :
+    {
+        . = ALIGN(4);
+        __tdata_start__ = .;
+        *(.tdata*)
+        *(.tdata_run)
+        . = ALIGN(4);
+        __tdata_end__ = .;
+    } > RAM AT > FLASH
+    __tdata_load_start__ = LOADADDR(.tdata);
+
+    /* Same trick for the runtime-test pattern in cpu.c: if start == load,
+     * the copy loop skips. */
+
+    /* ── Uninitialized data: zero'd by reset_handler ────────────── */
+
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    .tbss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        __tbss_start__ = .;
+        *(.tbss*)
+        __tbss_end__ = .;
+    } > RAM
+
+    /* ── Pinned TrustZone shared-data region at 0x20004000 ──────── */
+
+    .shared_data __shared_data_addr__ (NOLOAD) :
+    {
+        __shared_data_start__ = .;
+        KEEP(*(.shared_data))
+        . = ALIGN(4);
+        __shared_data_end__ = .;
+    } > RAM
+
+    /* ── Heap (empty for now) ──────────────────────────────────── */
+
+    .heap (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __heap_start__ = .;
+        . = . + __HEAPSIZE__;
+        __heap_end__ = .;
+    } > RAM
+
+    /* `end` is newlib's _sbrk marker (heap start). We don't malloc but
+     * linking pulls _sbrk in regardless via libc, so the symbol has
+     * to be defined or the link fails. */
+    PROVIDE(end  = __heap_start__);
+    PROVIDE(_end = __heap_start__);
+
+    /* ── Process stack (empty — no RTOS) ───────────────────────── */
+
+    .stack_process (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __stack_process_start__ = .;
+        . = . + __STACKSIZE_PROCESS__;
+        __stack_process_end__ = .;
+    } > RAM
+
+    /* ── Main stack at top of RAM1 ─────────────────────────────── */
+
+    .stack ORIGIN(RAM) + LENGTH(RAM) - __STACKSIZE__ (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __stack_start__ = .;
+        . = . + __STACKSIZE__;
+        __stack_end__ = .;
+    } > RAM
+
+    /DISCARD/ :
+    {
+        *(.ARM.exidx*)
+        *(.ARM.extab*)
+    }
+}

--- a/projects/cmake_hello/CMakeLists.txt
+++ b/projects/cmake_hello/CMakeLists.txt
@@ -1,0 +1,41 @@
+# cmake_hello — minimal LED blinker; the canonical "did the CMake
+# build pipeline come together?" smoke test.
+
+# Startup, vector table, and system_init all come from dotbot-libs
+# (nRF/System/cpu.c + nRF5340_xxAA_Application_cpu.c + system_init.c),
+# pulled in via the `dotbot_libs` INTERFACE sources. No .S file needed
+# — aabadie wrote the whole startup in C. The linker just needs the
+# matching script.
+set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/cmake/targets/nrf5340-app/nrf5340_app.ld)
+
+add_executable(cmake_hello main.c)
+
+target_link_libraries(cmake_hello PRIVATE dotbot_libs)
+
+target_include_directories(cmake_hello PRIVATE
+    ${NRFX_MDK_INCLUDE}     # nrf.h + Nordic peripheral headers (still consumer-supplied)
+    ${CMSIS_CORE_INCLUDE}   # core_cm33.h, __WFE, etc.
+)
+
+target_compile_definitions(cmake_hello PRIVATE
+    NRF5340_XXAA
+    NRF_APPLICATION
+    __NRF_FAMILY
+    BOARD_DOTBOT_V3
+)
+
+target_link_options(cmake_hello PRIVATE
+    -T${LINKER_SCRIPT}
+    -Wl,-Map=${CMAKE_CURRENT_BINARY_DIR}/cmake_hello.map
+)
+
+set_target_properties(cmake_hello PROPERTIES LINK_DEPENDS ${LINKER_SCRIPT})
+
+add_custom_command(TARGET cmake_hello POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -O ihex   $<TARGET_FILE:cmake_hello> ${CMAKE_CURRENT_BINARY_DIR}/cmake_hello.hex
+    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:cmake_hello> ${CMAKE_CURRENT_BINARY_DIR}/cmake_hello.bin
+    COMMAND ${CMAKE_SIZE} $<TARGET_FILE:cmake_hello>
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/cmake_hello.hex
+               ${CMAKE_CURRENT_BINARY_DIR}/cmake_hello.bin
+    COMMENT "cmake_hello: hex + bin"
+)

--- a/projects/cmake_hello/CMakeLists.txt
+++ b/projects/cmake_hello/CMakeLists.txt
@@ -11,11 +11,8 @@ set(LINKER_SCRIPT ${CMAKE_SOURCE_DIR}/cmake/targets/nrf5340-app/nrf5340_app.ld)
 add_executable(cmake_hello main.c)
 
 target_link_libraries(cmake_hello PRIVATE dotbot_libs)
-
-target_include_directories(cmake_hello PRIVATE
-    ${NRFX_MDK_INCLUDE}     # nrf.h + Nordic peripheral headers (still consumer-supplied)
-    ${CMSIS_CORE_INCLUDE}   # core_cm33.h, __WFE, etc.
-)
+# Nordic MDK + ARM CMSIS-Core headers come transitively via dotbot_libs
+# (which inherits from dotbot_nordic) — no need to list them here.
 
 target_compile_definitions(cmake_hello PRIVATE
     NRF5340_XXAA

--- a/projects/cmake_hello/main.c
+++ b/projects/cmake_hello/main.c
@@ -1,0 +1,44 @@
+/*
+ * cmake_hello — minimal LED blinker validating the DotBot-firmware
+ * CMake build path against the dotbot_libs INTERFACE target.
+ *
+ * Touches both kinds of headers we plumbed in:
+ *   * dotbot-libs (gpio.h, board.h, timer.h, board_config.h) — via
+ *     the `dotbot_libs` INTERFACE target's PUBLIC include dirs.
+ *   * Nordic MDK / ARM CMSIS-Core (nrf.h → __WFE intrinsic) — via
+ *     the FetchContent paths exposed as ${NRFX_MDK_INCLUDE} and
+ *     ${CMSIS_CORE_INCLUDE} from the root CMakeLists.
+ *
+ * Pin selection comes from the BOARD_* preprocessor define
+ * (BOARD_DOTBOT_V3 by default). DB_LED1 → P1.05 on DotBot v3 —
+ * the blue channel of the discrete RGB LED.
+ *
+ * Blink is interrupt-driven: a 500 ms periodic timer toggles the
+ * LED in its ISR; main() just sleeps on WFE between events.
+ */
+
+#include "nrf.h"            /* __WFE — confirms CMSIS-Core is on the path */
+#include "board.h"
+#include "board_config.h"
+#include "gpio.h"
+#include "timer.h"
+
+#define TIMER_DEV  0
+#define BLINK_MS   500
+
+static const gpio_t _heartbeat = { .port = DB_LED1_PORT, .pin = DB_LED1_PIN };
+
+static void on_tick(void) {
+    db_gpio_toggle(&_heartbeat);
+}
+
+int main(void) {
+    db_board_init();
+    db_gpio_init(&_heartbeat, DB_GPIO_OUT);
+    db_timer_init(TIMER_DEV);
+    db_timer_set_periodic_ms(TIMER_DEV, 0, BLINK_MS, on_tick);
+
+    for (;;) {
+        __WFE();   /* sleep until the timer ISR (or any event) fires */
+    }
+}


### PR DESCRIPTION
## Summary

First step toward CMake + `gcc-arm-none-eabi` support in DotBot-firmware (firmware-unification plan Phase 2). Adds:

- A root **`CMakeLists.txt`** wiring up `gcc-arm-none-eabi` flags, Nordic MDK + ARM CMSIS-Core via `FetchContent`, and a `DOTBOT_LIBS` cache var for pointing at either the bundled submodule (default — CI / fresh-clone) or a local checkout (dev iteration).
- A **toolchain file** (`cmake/arm-none-eabi.cmake`).
- A **GNU `.ld` script** (`cmake/targets/nrf5340-app/nrf5340_app.ld`) translated from dotbot-libs's SES placement XML — same memory map, same symbol names, same fixed `.shared_data` address (`0x20004000`).
- A minimal **`projects/cmake_hello/`** app validating the whole chain — interrupt-driven blink using `db_gpio_*` and `db_timer_*` with `__WFE()` in main loop.
- **`AGENTS.md` + `CLAUDE.md`** workspace orientation files (second commit).

**Strictly additive.** Existing `projects/*` apps and their `.emProject` files continue to work unchanged in SES.

## Pure-C startup (no `.S` file)

Uses dotbot-libs's `nRF/System/cpu.c` (`reset_handler` in C) + `nRF5340_xxAA_Application_cpu.c` (vector table as a C array in `.vectors` section) + `nRF5340_xxAA_Application_system_init.c` (clock + SAU + Errata 97). These come into the build via dotbot-libs's `dotbot_libs` INTERFACE target (DotBots/DotBot-libs#20, pending merge). **Same C code SES compiles; only the linker script syntax differs.**

## Dev workflow

```bash
# CI / fresh-clone: uses bundled submodule
cmake -B build -DCMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi.cmake -G Ninja
cmake --build build

# Dev: override to your local DotBot-libs checkout
cmake -B build -DCMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi.cmake \
      -DDOTBOT_LIBS=/path/to/local/DotBot-libs -G Ninja
```

## Validated on real hardware

`projects/cmake_hello/` flashed to a DotBot v3 (probe S/N \`772383387\`) — blue LED blinks at exactly 1 Hz, interrupt-driven via \`db_timer_set_periodic_ms\` + \`__WFE()\`. Confirms:

- gcc-arm-none-eabi compiles dotbot-libs's pure-C startup chain.
- Vector table loads correctly at flash origin; \`reset_handler\` executes.
- Linker script properly defines all the symbols cpu.c needs (\`__data_start__\`, \`__bss_end__\`, \`__shared_data_start__\` at \`0x20004000\`, etc.).
- RTC0 IRQ vector resolves to the dotbot-libs handler via the weak-alias mechanism in \`nRF5340_xxAA_Application_cpu.c\`.

## Depends on

[DotBots/DotBot-libs#20](https://github.com/DotBots/DotBot-libs/pull/20) — adds the CMake target in dotbot-libs that this PR consumes. Don't merge this PR until #20 lands and the submodule pin is bumped to include it. (For dev iteration: pass `-DDOTBOT_LIBS=/path/to/local/DotBot-libs` pointing at a checkout with #20's branch.)

## Followups (not in this PR)

- More dotbot-libs sources in the INTERFACE target (lh2, control_loop, hdlc, ...) as separate PRs to DotBot-libs.
- More existing apps under \`projects/\` getting their own \`CMakeLists.txt\` (next likely: \`projects/dotbot\`).
- nRF52833/nRF52840 build support (Cortex-M4, different per-chip cpu.c).
- Behavioral CI gate validating SES- and CMake-built binaries pass the same hardware regression tests.