### PR TITLE
.github: split bare/sandbox CI by path, unify release, ship hex/bin

### DIFF
--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -1,0 +1,45 @@
+name: CI sandbox
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'apps-sandbox/**'
+      - 'sandbox-*.emProject'
+      - 'Makefile'
+      - 'dotbot-libs'
+      - '.github/workflows/build-sandbox.yml'
+  pull_request:
+    # Only run when sandbox apps or shared build infra change.
+    paths:
+      - 'apps-sandbox/**'
+      - 'sandbox-*.emProject'
+      - 'Makefile'
+      - 'dotbot-libs'
+      - '.github/workflows/build-sandbox.yml'
+
+jobs:
+  build-sandbox:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ["sandbox-dotbot-v2", "sandbox-dotbot-v3", "sandbox-nrf5340dk"]
+        config: ["Release"]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: Build sandbox apps
+        run: BUILD_TARGET=${{ matrix.target }} BUILD_CONFIG=${{ matrix.config }} make docker
+
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Check style
+        run: make check-format

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,19 @@
-name: CI 
+name: CI
 
 on:
   push:
     branches:
       - main
-    tags: '*'
-
+      - develop
+    paths-ignore:
+      - 'apps-sandbox/**'
+      - 'sandbox-*.emProject'
   pull_request:
+    # Sandbox-only changes are covered by build-sandbox.yml; skip the bare
+    # build for them. Shared infra (Makefile, dotbot-libs, ...) still runs both.
+    paths-ignore:
+      - 'apps-sandbox/**'
+      - 'sandbox-*.emProject'
 
 jobs:
   build:
@@ -21,36 +28,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'true'
+      - name: Deprecation notice
+        if: contains(fromJSON('["dotbot-v1", "freebot-v1.0", "lh2-mini-mote"]'), matrix.target)
+        run: echo "::warning title=Planned deprecation::Board target '${{ matrix.target }}' is planned for deprecation around November 2026."
       - name: Build apps
-        run: BUILD_TARGET=${{ matrix.target }} BUILD_CONFIG=${{ matrix.config }} make docker
-      - name: Build for release and convert elf artifacts to hex
-        if: matrix.config == 'Release'
-        run: BUILD_TARGET=${{ matrix.target }} DOCKER_TARGETS="artifacts" BUILD_CONFIG=${{ matrix.config }} make docker
-      - name: Upload artifact
-        if: matrix.config == 'Release'
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts-${{ matrix.target }}
-          path: artifacts/*
-
-  build-sandbox:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ["sandbox-dotbot-v2", "sandbox-dotbot-v3", "sandbox-nrf5340dk"]
-        config: ["Debug", "Release"]
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          submodules: 'true'
-      - name: Build sandbox apps
         run: BUILD_TARGET=${{ matrix.target }} BUILD_CONFIG=${{ matrix.config }} make docker
 
   build-success:
     # this is only run if all builds succeeded
-    needs: [build, build-sandbox]
+    needs: build
     runs-on: ubuntu-latest
     steps:
     - name: build succeeded
@@ -87,80 +73,3 @@ jobs:
   #       uses: actions/checkout@v4
   #     - name: Build docker image
   #       run: docker build -t dotbot .
-
-  release:
-    runs-on: ubuntu-latest
-    # needs: [docker, doc, style, build-success]
-    needs: [doc, style, build-success]
-    if: >-
-      github.event_name == 'push' &&
-      startsWith(github.event.ref, 'refs/tags')
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Download DotBot v1 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-dotbot-v1
-          path: ./artifacts
-      - name: Download DotBot v2 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-dotbot-v2
-          path: ./artifacts
-      - name: Download DotBot v3 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-dotbot-v3
-          path: ./artifacts
-      - name: Download Sailbot v1 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-sailbot-v1
-          path: ./artifacts
-      - name: Download nRF52833DK artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-nrf52833dk
-          path: ./artifacts
-      - name: Download nRF52840DK artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-nrf52840dk
-          path: ./artifacts
-      - name: Download nRF5340DK application artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-nrf5340dk-app
-          path: ./artifacts
-      - name: Download nRF5340DK network artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-nrf5340dk-net
-          path: ./artifacts
-      - name: Download Freebot artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-freebot-v1.0
-          path: ./artifacts
-      - name: Download XGO v1 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-xgo-v1
-          path: ./artifacts
-      - name: Download XGO v2 artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-xgo-v2
-          path: ./artifacts
-      - name: Download LH2 mini mote artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-lh2-mini-mote
-          path: ./artifacts
-      - name: Release
-        uses: ncipollo/release-action@v1
-        with:
-          generateReleaseNotes: true
-          artifacts: "artifacts/*"
-          token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags: '*'
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Bare boards ship .hex, sandbox boards ship .bin (flashed by swarmit).
+        # The output format per target is driven by the Makefile (ARTIFACT_FMT).
+        target: ["dotbot-v2", "dotbot-v3", "sandbox-dotbot-v2", "sandbox-dotbot-v3"]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: Build release artifacts
+        run: BUILD_TARGET=${{ matrix.target }} BUILD_CONFIG=Release DOCKER_TARGETS="artifacts" make docker
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.target }}
+          path: artifacts/*
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build-release
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: ./artifacts
+          merge-multiple: true
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          artifacts: "artifacts/*"
+          token: ${{ secrets.RELEASE_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,18 @@ ifeq ($(QUIET),1)
   VERBOSE_OPTS =
 endif
 
+# Sandbox (TrustZone non-secure) apps live under apps-sandbox/ and are flashed
+# over the air with swarmit, which consumes a raw .bin. Bare apps live under
+# apps/ and ship as .hex. These mirror linker_output_format in the .emProject
+# solutions (sandbox-*: bin, bare: hex).
+ifneq (,$(filter sandbox-%,$(BUILD_TARGET)))
+  APPS_DIR := apps-sandbox
+  ARTIFACT_FMT := bin
+else
+  APPS_DIR := apps
+  ARTIFACT_FMT := hex
+endif
+
 ifeq (nrf5340dk-app,$(BUILD_TARGET))
   PROJECTS ?= \
     dotbot \
@@ -47,6 +59,8 @@ else ifneq (,$(filter xgo%,$(BUILD_TARGET)))
 else ifneq (,$(filter sandbox-%,$(BUILD_TARGET)))
   # Sandbox (TrustZone non-secure) targets build the apps under apps-sandbox/
   PROJECTS ?= $(shell find apps-sandbox/ -maxdepth 1 -mindepth 1 -type d | tr -d "/" | sed -e s/apps-sandbox// | sort)
+  # Release every sandbox app (CI gates the artifact upload to dotbot-v3)
+  ARTIFACT_PROJECTS := $(PROJECTS)
 else
   PROJECTS ?= $(shell find apps/ -maxdepth 1 -mindepth 1 -type d | tr -d "/" | sed -e s/apps// | sort)
 endif
@@ -97,9 +111,8 @@ SRCS ?= $(foreach dir,$(DIRS),$(shell find $(dir) -name "*.[c|h]"))
 CLANG_FORMAT ?= clang-format
 CLANG_FORMAT_TYPE ?= file
 
-ARTIFACT_ELF = $(foreach app,$(ARTIFACT_PROJECTS),apps/$(app)/Output/$(BUILD_TARGET)/$(BUILD_CONFIG)/Exe/$(app)-$(BUILD_TARGET).elf)
-ARTIFACT_HEX = $(ARTIFACT_ELF:.elf=.hex)
-ARTIFACTS = $(ARTIFACT_ELF) $(ARTIFACT_HEX)
+ARTIFACT_BASE = $(foreach app,$(ARTIFACT_PROJECTS),$(APPS_DIR)/$(app)/Output/$(BUILD_TARGET)/$(BUILD_CONFIG)/Exe/$(app)-$(BUILD_TARGET))
+ARTIFACTS = $(addsuffix .$(ARTIFACT_FMT),$(ARTIFACT_BASE))
 
 
 .PHONY: $(PROJECTS) $(ARTIFACT_PROJECTS) artifacts docker docker-release format check-format


### PR DESCRIPTION
Follow-up to the naming/`apps-sandbox` work (#408). The always-on sandbox build job added there rebuilt all 7 sandbox apps × 3 boards × 2 configs on **every** PR, roughly doubling CI time even for PRs that can't touch sandbox code. This restructures CI so each half only runs when relevant, and reworks releases.

## CI: three workflows

| File | Trigger | Does |
|---|---|---|
| `build.yml` | PR/push, `paths-ignore` sandbox | bare compile (12 targets × Debug/Release) + style + doc |
| `build-sandbox.yml` | PR/push, `paths` sandbox | sandbox compile (3 boards × Release) + style |
| `release.yml` | tags only | build v2+v3 bare+sandbox, one unified release |

The build workflows are now pure compile/lint checks — no release jobs, no tag triggers. A sandbox-only PR skips the bare matrix entirely (and vice-versa); shared infra (`Makefile`, `dotbot-libs`) triggers both.

## Releases

`release.yml` builds its own artifacts in one run, so a single `release` job collects everything (`download-artifact` `pattern: artifacts-*` + `merge-multiple`) and publishes **one** release — each `.hex`/`.bin` as a separate asset (no zip, no `allowUpdates` race). Scope:

- **bare** → `dotbot-v2`, `dotbot-v3` as `.hex`
- **sandbox** → all sandbox apps for `sandbox-dotbot-v2`, `sandbox-dotbot-v3` as `.bin` (the format swarmit OTA flashes)

Note: this drops v1/sailbot/freebot/xgo/nrf52833dk/nrf52840dk/nrf5340dk/lh2-mini-mote firmware from *releases* (they still compile in CI). Bare releases are now v2+v3 only, by request.

## Makefile

`ARTIFACT_FMT` (bin for `sandbox-*`, hex otherwise) mirrors each solution's `linker_output_format`; sandbox targets set `ARTIFACT_PROJECTS` to all their apps; `ARTIFACTS` drops the `.elf` (debug image, not flashable). Resolved paths verified locally for `dotbot-v3` (`.hex`) and `sandbox-dotbot-v3` (7 × `.bin`).

## Deprecation notice

`dotbot-v1`, `freebot-v1.0`, `lh2-mini-mote` builds now emit a CI `::warning::` flagging planned deprecation around November 2026.

## Validation

All three workflows YAML-valid; Makefile artifact resolution checked locally. `release.yml` first runs at the next tag — that's where the sandbox `.bin` artifact paths get exercised end-to-end on the SES image.