### PR TITLE
apps/dotbot: migrate from tdma to bare-radio + mari-shaped frame

### DIFF
--- a/apps/apps-dotbot.emProject
+++ b/apps/apps-dotbot.emProject
@@ -3,7 +3,7 @@
   <project Name="dotbot">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_dotbot_board(bsp);00bsp_dotbot_lh2(bsp);00bsp_timer(bsp);00drv_dotbot_battery(drv);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00drv_log_flash(drv);00drv_rgbled_pwm(drv);00drv_motors(drv);00drv_tdma_client(drv);00drv_dotbot_control_loop(drv);00bsp_qdec(bsp)"
+      project_dependencies="00bsp_dotbot_board(bsp);00bsp_dotbot_lh2(bsp);00bsp_timer(bsp);00drv_dotbot_battery(drv);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00drv_log_flash(drv);00drv_rgbled_pwm(drv);00drv_motors(drv);00drv_dotbot_control_loop(drv);00bsp_qdec(bsp)"
       project_directory="dotbot"
       project_type="Executable" />
     <folder Name="Setup">

--- a/apps/apps-freebot-v1.0.emProject
+++ b/apps/apps-freebot-v1.0.emProject
@@ -3,7 +3,7 @@
   <project Name="freebot">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_timer(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00bsp_pwm(bsp);00drv_tdma_client(drv)"
+      project_dependencies="00bsp_timer(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00bsp_pwm(bsp)"
       project_directory="freebot"
       project_type="Executable" />
     <folder Name="Setup">

--- a/apps/apps-gateway.emProject
+++ b/apps/apps-gateway.emProject
@@ -3,7 +3,7 @@
   <project Name="dotbot_gateway">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_radio(bsp);00bsp_dotbot_board(bsp);00bsp_uart(bsp);00bsp_timer(bsp);00bsp_uart(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_gpio(bsp);00drv_tdma_server(drv)"
+      project_dependencies="00bsp_radio(bsp);00bsp_dotbot_board(bsp);00bsp_uart(bsp);00bsp_timer(bsp);00bsp_uart(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_gpio(bsp)"
       project_directory="dotbot_gateway"
       project_type="Executable" />
     <folder Name="Setup">
@@ -31,7 +31,7 @@
 <project Name="dotbot_gateway_lr">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_radio(bsp);00bsp_dotbot_board(bsp);00bsp_uart(bsp);00bsp_timer(bsp);00bsp_uart(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_gpio(bsp);00drv_tdma_server(drv)"
+      project_dependencies="00bsp_radio(bsp);00bsp_dotbot_board(bsp);00bsp_uart(bsp);00bsp_timer(bsp);00bsp_uart(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_gpio(bsp)"
       project_directory="dotbot_gateway_lr"
       project_type="Executable" />
     <folder Name="Setup">

--- a/apps/apps-lh2-minimote.emProject
+++ b/apps/apps-lh2-minimote.emProject
@@ -3,7 +3,7 @@
   <project Name="lh2_mini_mote_app">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_dotbot_board(bsp);00bsp_dotbot_lh2(bsp);00bsp_timer(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00drv_log_flash(drv);00drv_rgbled_pwm(drv);00drv_tdma_client(drv)"
+      project_dependencies="00bsp_dotbot_board(bsp);00bsp_dotbot_lh2(bsp);00bsp_timer(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00drv_log_flash(drv);00drv_rgbled_pwm(drv)"
       project_directory="lh2_mini_mote_app"
       project_type="Executable" />
     <folder Name="Setup">
@@ -27,7 +27,7 @@
   <project Name="lh2_mini_mote_test">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_dotbot_board(bsp);00bsp_dotbot_lh2(bsp);00bsp_timer(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00drv_log_flash(drv);00drv_rgbled_pwm(drv);00drv_ism330(drv);00drv_tdma_client(drv)"
+      project_dependencies="00bsp_dotbot_board(bsp);00bsp_dotbot_lh2(bsp);00bsp_timer(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00drv_log_flash(drv);00drv_rgbled_pwm(drv);00drv_ism330(drv)"
       project_directory="lh2_mini_mote_test"
       project_type="Executable" />
     <folder Name="Setup">

--- a/apps/apps-nrf5340-net.emProject
+++ b/apps/apps-nrf5340-net.emProject
@@ -3,7 +3,7 @@
   <project Name="nrf5340_net">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_radio(bsp);00bsp_rng(bsp);00drv_tdma_client(drv);00drv_tdma_server(drv);"
+      project_dependencies="00bsp_radio(bsp);00bsp_rng(bsp);"
       project_directory="nrf5340_net"
       project_type="Executable" />
     <folder Name="Setup">

--- a/apps/apps-sailbot.emProject
+++ b/apps/apps-sailbot.emProject
@@ -3,7 +3,7 @@
   <project Name="sailbot">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_imu(drv);00drv_as5048b(drv);00drv_tdma_client(drv)"
+      project_dependencies="00bsp_radio(bsp);00bsp_uart(bsp);00drv_dotbot_protocol(drv);00bsp_pwm(bsp);00bsp_timer_hf(bsp);00bsp_timer(bsp);00bsp_i2c(bsp);00drv_imu(drv);00drv_as5048b(drv)"
       project_directory="sailbot"
       project_type="Executable" />
     <folder Name="Setup">

--- a/apps/apps-xgo.emProject
+++ b/apps/apps-xgo.emProject
@@ -3,7 +3,7 @@
   <project Name="xgo">
     <configuration
       Name="Common"
-      project_dependencies="00bsp_uart(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00bsp_timer_hf(bsp);00drv_tdma_client(drv)"
+      project_dependencies="00bsp_uart(bsp);00drv_dotbot_hdlc(drv);00drv_dotbot_protocol(drv);00bsp_radio(bsp);00bsp_timer_hf(bsp)"
       project_directory="xgo"
       project_type="Executable" />
     <folder Name="Setup">

--- a/apps/dotbot/main.c
+++ b/apps/dotbot/main.c
@@ -264,17 +264,11 @@ int main(void) {
                     calibration_complete |= (1 << i);
                 }
             }
-            // Frame is [21B mari-shaped header][1B payload-type tag][advertisement payload].
-            // The payload-type tag (DB_PROTOCOL_DOTBOT_ADVERTISEMENT) and the
-            // bytes after it are unchanged from the legacy wire format — only
-            // the framing header changed.
-            size_t length                       = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
-            _dotbot_vars.radio_buffer[length++] = DB_PROTOCOL_DOTBOT_ADVERTISEMENT;
-            _dotbot_vars.radio_buffer[length++] = calibration_complete;
-            int16_t                 direction   = 0xFFFF;
-            protocol_lh2_location_t position    = {
-                   .x = 0xffffffff,
-                   .y = 0xffffffff,
+            size_t                  length    = db_protocol_dotbot_advertizement_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS, calibration_complete);
+            int16_t                 direction = 0xFFFF;
+            protocol_lh2_location_t position  = {
+                 .x = 0xffffffff,
+                 .y = 0xffffffff,
             };
             if (calibration_complete) {
                 direction  = _control_vars.direction;

--- a/apps/dotbot/main.c
+++ b/apps/dotbot/main.c
@@ -29,13 +29,12 @@
 #include "rgbled_pwm.h"
 #include "timer.h"
 #include "log_flash.h"
-#include "tdma_client.h"
+#include "frame.h"
 #include "battery.h"
 #include "control_loop.h"
 
 //=========================== defines ==========================================
 
-#define DB_RADIO_FREQ             (8U)      ///< Set the frequency to 2408 MHz
 #define RADIO_APP                 (DotBot)  ///< DotBot Radio App
 #define TIMER_DEV                 (0)
 #define QDEC_LEFT                 (0)      ///< Left wheel QDEC peripheral index
@@ -97,22 +96,26 @@ static void _update_lh2(void);
 //=========================== callbacks ========================================
 
 static void radio_callback(uint8_t *pkt, uint8_t len) {
-    (void)len;
+    if (len < sizeof(db_frame_header_t) + 1) {
+        return;
+    }
 
     _dotbot_vars.ts_last_packet_received = db_timer_ticks(TIMER_DEV);
-    uint8_t           *ptk_ptr           = pkt;
-    protocol_header_t *header            = (protocol_header_t *)ptk_ptr;
-    // Check destination address matches
-    if (header->dst != DB_BROADCAST_ADDRESS && header->dst != _dotbot_vars.device_id) {
+    db_frame_header_t *header            = (db_frame_header_t *)pkt;
+
+    // Drop frames addressed elsewhere
+    if (header->dst != DB_FRAME_DST_BROADCAST && header->dst != _dotbot_vars.device_id) {
         return;
     }
 
-    // Check version is supported
-    if (header->version != DB_FIRMWARE_VERSION) {
+    // Drop wrong version / wrong upper-layer protocol
+    if (header->version != DB_FRAME_VERSION ||
+        header->type != DB_FRAME_TYPE_DATA ||
+        header->next_proto != DB_FRAME_NEXT_PROTO) {
         return;
     }
 
-    uint8_t *cmd_ptr = ptk_ptr + sizeof(protocol_header_t);
+    uint8_t *cmd_ptr = pkt + sizeof(db_frame_header_t);
     // parse received packet and update the motors' speeds
     switch ((uint8_t)*cmd_ptr++) {
         case DB_PROTOCOL_CMD_MOVE_RAW:
@@ -180,7 +183,10 @@ int main(void) {
     db_qdec_init(QDEC_LEFT, &_qdec_left_conf, NULL, NULL);
     db_qdec_init(QDEC_RIGHT, &_qdec_right_conf, NULL, NULL);
     _control_ctx = control_loop_alloc();
-    db_tdma_client_init(&radio_callback, DB_RADIO_BLE_1MBit, DB_RADIO_FREQ);
+    db_radio_init(&radio_callback, DB_RADIO_BLE_1MBit);
+    db_radio_set_network_address(DB_FRAME_ACCESS_ADDR);
+    db_radio_set_frequency(DB_FRAME_DEFAULT_FREQ);
+    db_radio_rx();
 
     // Set an invalid heading since the value is unknown on startup.
     // Control loop is stopped
@@ -258,11 +264,17 @@ int main(void) {
                     calibration_complete |= (1 << i);
                 }
             }
-            size_t                  length    = db_protocol_dotbot_advertizement_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS, calibration_complete);
-            int16_t                 direction = 0xFFFF;
-            protocol_lh2_location_t position  = {
-                 .x = 0xffffffff,
-                 .y = 0xffffffff,
+            // Frame is [21B mari-shaped header][1B payload-type tag][advertisement payload].
+            // The payload-type tag (DB_PROTOCOL_DOTBOT_ADVERTISEMENT) and the
+            // bytes after it are unchanged from the legacy wire format — only
+            // the framing header changed.
+            size_t length                       = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+            _dotbot_vars.radio_buffer[length++] = DB_PROTOCOL_DOTBOT_ADVERTISEMENT;
+            _dotbot_vars.radio_buffer[length++] = calibration_complete;
+            int16_t                 direction   = 0xFFFF;
+            protocol_lh2_location_t position    = {
+                   .x = 0xffffffff,
+                   .y = 0xffffffff,
             };
             if (calibration_complete) {
                 direction  = _control_vars.direction;
@@ -288,7 +300,9 @@ int main(void) {
             memcpy(&_dotbot_vars.radio_buffer[length], &_control_vars.waypoint_y, sizeof(uint32_t));
             length += sizeof(uint32_t);
             memcpy(&_dotbot_vars.radio_buffer[length++], &_control_vars.waypoint_idx, sizeof(uint8_t));
-            db_tdma_client_tx(_dotbot_vars.radio_buffer, length);
+            db_radio_disable();
+            db_radio_tx(_dotbot_vars.radio_buffer, length);
+            db_radio_rx();
             _dotbot_vars.advertize = false;
         }
     }

--- a/apps/dotbot_gateway/dotbot_gateway.c
+++ b/apps/dotbot_gateway/dotbot_gateway.c
@@ -167,12 +167,7 @@ int main(void) {
         bool send_command = (command.left_y != 0) || (command.right_y != 0) || (command.left_y == 0 && command.left_y != prev_left) || (command.right_y == 0 && command.right_y != prev_right);
         if (send_command) {
 
-            // Build the same wire format the dotbot app expects:
-            // [21B mari-shaped header][1B payload-type tag][MoveRaw payload].
-            size_t tx_len                      = db_frame_header_to_buffer(_gw_vars.radio_tx_buffer, DB_BROADCAST_ADDRESS);
-            _gw_vars.radio_tx_buffer[tx_len++] = DB_PROTOCOL_CMD_MOVE_RAW;
-            memcpy(&_gw_vars.radio_tx_buffer[tx_len], &command, sizeof(command));
-            tx_len += sizeof(command);
+            size_t tx_len = db_protocol_cmd_move_raw_to_buffer(_gw_vars.radio_tx_buffer, DB_BROADCAST_ADDRESS, &command);
             db_radio_disable();
             db_radio_tx(_gw_vars.radio_tx_buffer, tx_len);
             db_radio_rx();

--- a/apps/dotbot_gateway/dotbot_gateway.c
+++ b/apps/dotbot_gateway/dotbot_gateway.c
@@ -134,7 +134,9 @@ int main(void) {
     db_board_init();
 
     // Configure Radio in bare mode (matches the dotbot app's RF settings).
-    db_radio_init(&_radio_callback, DB_RADIO_BLE_1MBit);
+    // PHY mode comes from the variant's conf.h (1MBit for the standard
+    // gateway, LR125Kbit for dotbot_gateway_lr — paired with sailbot).
+    db_radio_init(&_radio_callback, DOTBOT_GW_RADIO_MODE);
     db_radio_set_network_address(DB_FRAME_ACCESS_ADDR);
     db_radio_set_frequency(DB_FRAME_DEFAULT_FREQ);
     db_radio_rx();

--- a/apps/dotbot_gateway/dotbot_gateway.c
+++ b/apps/dotbot_gateway/dotbot_gateway.c
@@ -6,12 +6,20 @@
 // Include BSP headers
 #include "board.h"
 #include "board_config.h"
+#include "frame.h"
 #include "gpio.h"
 #include "hdlc.h"
 #include "protocol.h"
+#include "radio.h"
 #include "timer.h"
 #include "uart.h"
-#include "tdma_server.h"
+
+/// MarilibEdge UART event type for in-band data frames. Mirrors
+/// `MARI_EDGE_DATA` from `mari/firmware/mari/models.h` (= 3). The gateway
+/// wraps every received bare-radio frame with this byte before HDLC-
+/// encoding, so PyDotBot's MarilibEdge adapter parses it identically to
+/// a real Mari gateway's emit.
+#define DB_EDGE_EVENT_DATA (3)
 
 //=========================== defines ==========================================
 
@@ -24,7 +32,6 @@
 #define DB_UART_INDEX (0)  ///< Index of UART peripheral to use
 #endif
 #define DB_RADIO_QUEUE_SIZE (8U)                             ///< Size of the radio queue (must by a power of 2)
-#define DB_RADIO_FREQ       (8U)                             //< Set the frequency to 2408 MHz
 #define DB_UART_QUEUE_SIZE  ((DB_BUFFER_MAX_BYTES + 1) * 2)  ///< Size of the UART queue size (must by a power of 2)
 #define RADIO_APP           (DotBot)                         // DotBot Radio App
 
@@ -126,8 +133,11 @@ int main(void) {
 
     db_board_init();
 
-    // Configure Radio as transmitter
-    db_tdma_server_init(&_radio_callback, DOTBOT_GW_RADIO_MODE, DB_RADIO_FREQ);
+    // Configure Radio in bare mode (matches the dotbot app's RF settings).
+    db_radio_init(&_radio_callback, DB_RADIO_BLE_1MBit);
+    db_radio_set_network_address(DB_FRAME_ACCESS_ADDR);
+    db_radio_set_frequency(DB_FRAME_DEFAULT_FREQ);
+    db_radio_rx();
     // Initialize the gateway context
     _gw_vars.buttons             = 0x0000;
     _gw_vars.radio_queue.current = 0;
@@ -155,8 +165,15 @@ int main(void) {
         bool send_command = (command.left_y != 0) || (command.right_y != 0) || (command.left_y == 0 && command.left_y != prev_left) || (command.right_y == 0 && command.right_y != prev_right);
         if (send_command) {
 
-            db_protocol_cmd_move_raw_to_buffer(_gw_vars.radio_tx_buffer, DB_BROADCAST_ADDRESS, &command);
-            db_tdma_server_tx(_gw_vars.radio_tx_buffer, sizeof(protocol_header_t) + sizeof(protocol_move_raw_command_t) + sizeof(uint8_t));
+            // Build the same wire format the dotbot app expects:
+            // [21B mari-shaped header][1B payload-type tag][MoveRaw payload].
+            size_t tx_len                      = db_frame_header_to_buffer(_gw_vars.radio_tx_buffer, DB_BROADCAST_ADDRESS);
+            _gw_vars.radio_tx_buffer[tx_len++] = DB_PROTOCOL_CMD_MOVE_RAW;
+            memcpy(&_gw_vars.radio_tx_buffer[tx_len], &command, sizeof(command));
+            tx_len += sizeof(command);
+            db_radio_disable();
+            db_radio_tx(_gw_vars.radio_tx_buffer, tx_len);
+            db_radio_rx();
 
             prev_left  = command.left_y;
             prev_right = command.right_y;
@@ -166,7 +183,14 @@ int main(void) {
 
         while (_gw_vars.radio_queue.current != _gw_vars.radio_queue.last) {
             db_gpio_clear(&db_led2);
-            size_t frame_len = db_hdlc_encode(_gw_vars.radio_queue.packets[_gw_vars.radio_queue.current].buffer, _gw_vars.radio_queue.packets[_gw_vars.radio_queue.current].length, _gw_vars.hdlc_tx_buffer);
+            // Wrap the raw bare-radio frame as a MarilibEdge DATA event:
+            // [DB_EDGE_EVENT_DATA (1B)][frame bytes]. The host's MarilibEdge
+            // adapter strips the event byte and parses the rest as a mari Frame.
+            gateway_radio_packet_t *pkt = &_gw_vars.radio_queue.packets[_gw_vars.radio_queue.current];
+            uint8_t                 edge_buf[1 + DB_BUFFER_MAX_BYTES];
+            edge_buf[0] = DB_EDGE_EVENT_DATA;
+            memcpy(&edge_buf[1], pkt->buffer, pkt->length);
+            size_t frame_len = db_hdlc_encode(edge_buf, 1 + pkt->length, _gw_vars.hdlc_tx_buffer);
             db_uart_write(DB_UART_INDEX, _gw_vars.hdlc_tx_buffer, frame_len);
             _gw_vars.radio_queue.current = (_gw_vars.radio_queue.current + 1) & (DB_RADIO_QUEUE_SIZE - 1);
         }
@@ -182,8 +206,14 @@ int main(void) {
                 case DB_HDLC_STATE_READY:
                 {
                     size_t msg_len = db_hdlc_decode(_gw_vars.hdlc_rx_buffer);
-                    if (msg_len) {
-                        db_tdma_server_tx(_gw_vars.hdlc_rx_buffer, msg_len);
+                    // Host frames the TX request as [DB_EDGE_EVENT_DATA (1B)][frame bytes].
+                    // Drop anything that isn't a DATA event; transmit the remainder
+                    // straight onto the bare radio (the wire format already matches
+                    // what dotbots expect — no re-framing).
+                    if (msg_len > 1 && _gw_vars.hdlc_rx_buffer[0] == DB_EDGE_EVENT_DATA) {
+                        db_radio_disable();
+                        db_radio_tx(&_gw_vars.hdlc_rx_buffer[1], msg_len - 1);
+                        db_radio_rx();
                     }
                 } break;
                 default:

--- a/apps/freebot/main.c
+++ b/apps/freebot/main.c
@@ -24,12 +24,11 @@
 #include "radio.h"
 #include "timer.h"
 // Include DRV headers
-#include "tdma_client.h"
+#include "frame.h"
 
 //=========================== defines ==========================================
 
 #define TIMER_DEV                 (0)
-#define DB_RADIO_FREQ             (8)      //< Set the frequency to 2408 MHz
 #define DB_ADVERTIZEMENT_DELAY_MS (500U)   ///< 500ms delay between each advertizement packet sending
 #define DB_TIMEOUT_CHECK_DELAY_MS (200U)   ///< 200ms delay between each timeout delay check
 #define TIMEOUT_CHECK_DELAY_TICKS (17000)  ///< ~500 ms delay between packet received timeout checks
@@ -70,22 +69,25 @@ void        _motors_set(int16_t m1_speed, int16_t m2_speed, int16_t m3_speed, in
 //=========================== callbacks ========================================
 
 static void _radio_callback(uint8_t *pkt, uint8_t len) {
-    (void)len;
+    if (len < sizeof(db_frame_header_t) + 1) {
+        return;
+    }
 
     _freebot_vars.ts_last_packet_received = db_timer_ticks(TIMER_DEV);
-    uint8_t           *ptk_ptr            = pkt;
-    protocol_header_t *header             = (protocol_header_t *)ptk_ptr;
-    // Check destination address matches
-    if (header->dst != DB_BROADCAST_ADDRESS && header->dst != _freebot_vars.device_id) {
+    db_frame_header_t *header             = (db_frame_header_t *)pkt;
+    // Drop frames addressed elsewhere
+    if (header->dst != DB_FRAME_DST_BROADCAST && header->dst != _freebot_vars.device_id) {
         return;
     }
 
-    // Check version is supported
-    if (header->version != DB_FIRMWARE_VERSION) {
+    // Drop wrong version / wrong upper-layer protocol
+    if (header->version != DB_FRAME_VERSION ||
+        header->type != DB_FRAME_TYPE_DATA ||
+        header->next_proto != DB_FRAME_NEXT_PROTO) {
         return;
     }
 
-    uint8_t *cmd_ptr = ptk_ptr + sizeof(protocol_header_t);
+    uint8_t *cmd_ptr = pkt + sizeof(db_frame_header_t);
     // parse received packet and update the motors' speeds
     switch ((uint8_t)*cmd_ptr++) {
         case DB_PROTOCOL_CMD_MOVE_RAW:
@@ -105,7 +107,10 @@ static void _radio_callback(uint8_t *pkt, uint8_t len) {
 //=========================== main =============================================
 
 int main(void) {
-    db_tdma_client_init(&_radio_callback, DB_RADIO_BLE_1MBit, DB_RADIO_FREQ);
+    db_radio_init(&_radio_callback, DB_RADIO_BLE_1MBit);
+    db_radio_set_network_address(DB_FRAME_ACCESS_ADDR);
+    db_radio_set_frequency(DB_FRAME_DEFAULT_FREQ);
+    db_radio_rx();
 
     // db_gpio_init(&db_led1, DB_GPIO_OUT);
     //  Retrieve the device id once at startup
@@ -123,8 +128,12 @@ int main(void) {
 
         if (_freebot_vars.advertize) {
             // db_gpio_toggle(&db_led1);
-            size_t length = db_protocol_advertizement_to_buffer(_freebot_vars.radio_buffer, DB_GATEWAY_ADDRESS, DotBot);
-            db_tdma_client_tx(_freebot_vars.radio_buffer, length);
+            size_t length                        = db_frame_header_to_buffer(_freebot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+            _freebot_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
+            _freebot_vars.radio_buffer[length++] = DotBot;
+            db_radio_disable();
+            db_radio_tx(_freebot_vars.radio_buffer, length);
+            db_radio_rx();
             _freebot_vars.advertize = false;
         }
     }

--- a/apps/freebot/main.c
+++ b/apps/freebot/main.c
@@ -128,9 +128,7 @@ int main(void) {
 
         if (_freebot_vars.advertize) {
             // db_gpio_toggle(&db_led1);
-            size_t length                        = db_frame_header_to_buffer(_freebot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
-            _freebot_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
-            _freebot_vars.radio_buffer[length++] = DotBot;
+            size_t length = db_protocol_advertizement_to_buffer(_freebot_vars.radio_buffer, DB_GATEWAY_ADDRESS, DotBot);
             db_radio_disable();
             db_radio_tx(_freebot_vars.radio_buffer, length);
             db_radio_rx();

--- a/apps/lh2_mini_mote_app/main.c
+++ b/apps/lh2_mini_mote_app/main.c
@@ -27,12 +27,11 @@
 #include "rgbled_pwm.h"
 #include "timer_hf.h"
 // Include DRV headers
-#include "tdma_client.h"
+#include "frame.h"
 
 //=========================== defines ==========================================
 
 #define TIMER_DEV                 (0)
-#define DB_RADIO_FREQ             (8)        //< Set the frequency to 2408 MHz
 #define DB_LH2_UPDATE_DELAY_US    (100000U)  ///< 100ms delay between each LH2 data refresh
 #define DB_ADVERTISEMENT_DELAY_US (500000U)  ///< 500ms delay between each advertizement packet sending
 #define DB_BUFFER_MAX_BYTES       (255U)     ///< Max bytes in UART receive buffer
@@ -64,7 +63,10 @@ static void radio_callback(uint8_t *pkt, uint8_t len);
 int main(void) {
     db_board_init();
     _dotbot_vars.advertise = false;
-    db_tdma_client_init(&radio_callback, DB_RADIO_BLE_1MBit, DB_RADIO_FREQ);
+    db_radio_init(&radio_callback, DB_RADIO_BLE_1MBit);
+    db_radio_set_network_address(DB_FRAME_ACCESS_ADDR);
+    db_radio_set_frequency(DB_FRAME_DEFAULT_FREQ);
+    db_radio_rx();
 
     // Retrieve the device id once at startup
     _dotbot_vars.device_id = db_device_id();
@@ -90,7 +92,7 @@ int main(void) {
                     db_timer_hf_set_oneshot_us(TIMER_DEV, 0, 3000, &_turn_off_led);
 
                     // Prepare the radio buffer
-                    size_t length = db_protocol_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+                    size_t length = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
 
                     // Package data into a variable
                     protocol_lh2_processed_packet_t lh2_packet;
@@ -104,7 +106,9 @@ int main(void) {
                     length += sizeof(protocol_lh2_processed_packet_t);
 
                     // Send through radio
-                    db_tdma_client_tx(_dotbot_vars.radio_buffer, length);
+                    db_radio_disable();
+                    db_radio_tx(_dotbot_vars.radio_buffer, length);
+                    db_radio_rx();
 
                     // Mark the data as already sent
                     _dotbot_vars.lh2.data_ready[sweep][basestation] = DB_LH2_NO_NEW_DATA;
@@ -113,8 +117,12 @@ int main(void) {
         }
 
         if (_dotbot_vars.advertise) {
-            size_t length = db_protocol_advertizement_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS, LH2_mini_mote);
-            db_tdma_client_tx(_dotbot_vars.radio_buffer, length);
+            size_t length                       = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+            _dotbot_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
+            _dotbot_vars.radio_buffer[length++] = LH2_mini_mote;
+            db_radio_disable();
+            db_radio_tx(_dotbot_vars.radio_buffer, length);
+            db_radio_rx();
             _dotbot_vars.advertise = false;
         }
     }
@@ -133,22 +141,25 @@ static void _turn_off_led(void) {
 //=========================== callbacks ========================================
 
 static void radio_callback(uint8_t *pkt, uint8_t len) {
-    (void)len;
+    if (len < sizeof(db_frame_header_t) + 1) {
+        return;
+    }
 
     _dotbot_vars.ts_last_packet_received = db_timer_hf_now(TIMER_DEV);
-    uint8_t                 *ptk_ptr     = pkt;
-    const protocol_header_t *header      = (const protocol_header_t *)ptk_ptr;
-    // Check destination address matches
-    if (header->dst != DB_BROADCAST_ADDRESS && header->dst != _dotbot_vars.device_id) {
+    const db_frame_header_t *header      = (const db_frame_header_t *)pkt;
+    // Drop frames addressed elsewhere
+    if (header->dst != DB_FRAME_DST_BROADCAST && header->dst != _dotbot_vars.device_id) {
         return;
     }
 
-    // Check version is supported
-    if (header->version != DB_FIRMWARE_VERSION) {
+    // Drop wrong version / wrong upper-layer protocol
+    if (header->version != DB_FRAME_VERSION ||
+        header->type != DB_FRAME_TYPE_DATA ||
+        header->next_proto != DB_FRAME_NEXT_PROTO) {
         return;
     }
 
-    uint8_t *cmd_ptr = ptk_ptr + sizeof(protocol_header_t);
+    uint8_t *cmd_ptr = pkt + sizeof(db_frame_header_t);
     // parse received packet and update the motors' speeds
     switch ((uint8_t)*cmd_ptr++) {
 

--- a/apps/lh2_mini_mote_app/main.c
+++ b/apps/lh2_mini_mote_app/main.c
@@ -92,7 +92,7 @@ int main(void) {
                     db_timer_hf_set_oneshot_us(TIMER_DEV, 0, 3000, &_turn_off_led);
 
                     // Prepare the radio buffer
-                    size_t length = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+                    size_t length = db_protocol_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
 
                     // Package data into a variable
                     protocol_lh2_processed_packet_t lh2_packet;
@@ -117,9 +117,7 @@ int main(void) {
         }
 
         if (_dotbot_vars.advertise) {
-            size_t length                       = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
-            _dotbot_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
-            _dotbot_vars.radio_buffer[length++] = LH2_mini_mote;
+            size_t length = db_protocol_advertizement_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS, LH2_mini_mote);
             db_radio_disable();
             db_radio_tx(_dotbot_vars.radio_buffer, length);
             db_radio_rx();

--- a/apps/lh2_mini_mote_test/main.c
+++ b/apps/lh2_mini_mote_test/main.c
@@ -120,7 +120,7 @@ int main(void) {
                     db_timer_hf_set_oneshot_us(TIMER_DEV, 0, 3000, &_previous_led_color);
 
                     // Prepare the radio buffer
-                    size_t length = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+                    size_t length = db_protocol_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
 
                     // Package data into a variable
                     protocol_lh2_processed_packet_t lh2_packet;
@@ -152,9 +152,7 @@ int main(void) {
         }
 
         if (_dotbot_vars.advertise) {
-            size_t length                       = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
-            _dotbot_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
-            _dotbot_vars.radio_buffer[length++] = LH2_mini_mote;
+            size_t length = db_protocol_advertizement_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS, LH2_mini_mote);
             db_radio_disable();
             db_radio_tx(_dotbot_vars.radio_buffer, length);
             db_radio_rx();

--- a/apps/lh2_mini_mote_test/main.c
+++ b/apps/lh2_mini_mote_test/main.c
@@ -29,13 +29,13 @@
 #include "timer_hf.h"
 #include "timer.h"
 // Include DRV headers
+#include "frame.h"
 #include "ism330.h"
-#include "tdma_client.h"
+#include "radio.h"
 
 //=========================== defines ==========================================
 
 #define TIMER_DEV                 (0)
-#define DB_RADIO_FREQ             (28)       //< Set the frequency to 2408 MHz
 #define DB_LH2_UPDATE_DELAY_US    (100000U)  ///< 100ms delay between each LH2 data refresh
 #define IMU_COLOR_DELAY_US        (100000U)  ///< 100ms delay between each IMU color update
 #define DB_ADVERTISEMENT_DELAY_US (500000U)  ///< 500ms delay between each advertizement packet sending
@@ -82,7 +82,10 @@ static void _update_color(void);
 int main(void) {
     db_board_init();
     _dotbot_vars.advertise = false;
-    db_tdma_client_init(&radio_callback, DB_RADIO_BLE_1MBit, DB_RADIO_FREQ);
+    db_radio_init(&radio_callback, DB_RADIO_BLE_1MBit);
+    db_radio_set_network_address(DB_FRAME_ACCESS_ADDR);
+    db_radio_set_frequency(DB_FRAME_DEFAULT_FREQ);
+    db_radio_rx();
 
     // Retrieve the device id once at startup
     _dotbot_vars.device_id = db_device_id();
@@ -117,7 +120,7 @@ int main(void) {
                     db_timer_hf_set_oneshot_us(TIMER_DEV, 0, 3000, &_previous_led_color);
 
                     // Prepare the radio buffer
-                    size_t length = db_protocol_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+                    size_t length = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
 
                     // Package data into a variable
                     protocol_lh2_processed_packet_t lh2_packet;
@@ -131,7 +134,9 @@ int main(void) {
                     length += sizeof(protocol_lh2_processed_packet_t);
 
                     // Send through radio
-                    db_tdma_client_tx(_dotbot_vars.radio_buffer, length);
+                    db_radio_disable();
+                    db_radio_tx(_dotbot_vars.radio_buffer, length);
+                    db_radio_rx();
 
                     // Mark the data as already sent
                     _dotbot_vars.lh2.data_ready[sweep][basestation] = DB_LH2_NO_NEW_DATA;
@@ -147,8 +152,12 @@ int main(void) {
         }
 
         if (_dotbot_vars.advertise) {
-            size_t length = db_protocol_advertizement_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS, LH2_mini_mote);
-            db_tdma_client_tx(_dotbot_vars.radio_buffer, length);
+            size_t length                       = db_frame_header_to_buffer(_dotbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+            _dotbot_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
+            _dotbot_vars.radio_buffer[length++] = LH2_mini_mote;
+            db_radio_disable();
+            db_radio_tx(_dotbot_vars.radio_buffer, length);
+            db_radio_rx();
             _dotbot_vars.advertise = false;
         }
     }
@@ -231,22 +240,25 @@ static void _set_rgb_led(void) {
 //=========================== callbacks ========================================
 
 static void radio_callback(uint8_t *pkt, uint8_t len) {
-    (void)len;
+    if (len < sizeof(db_frame_header_t) + 1) {
+        return;
+    }
 
     _dotbot_vars.ts_last_packet_received = db_timer_hf_now(TIMER_DEV);
-    uint8_t                 *ptk_ptr     = pkt;
-    const protocol_header_t *header      = (const protocol_header_t *)ptk_ptr;
-    // Check destination address matches
-    if (header->dst != DB_BROADCAST_ADDRESS && header->dst != _dotbot_vars.device_id) {
+    const db_frame_header_t *header      = (const db_frame_header_t *)pkt;
+    // Drop frames addressed elsewhere
+    if (header->dst != DB_FRAME_DST_BROADCAST && header->dst != _dotbot_vars.device_id) {
         return;
     }
 
-    // Check version is supported
-    if (header->version != DB_FIRMWARE_VERSION) {
+    // Drop wrong version / wrong upper-layer protocol
+    if (header->version != DB_FRAME_VERSION ||
+        header->type != DB_FRAME_TYPE_DATA ||
+        header->next_proto != DB_FRAME_NEXT_PROTO) {
         return;
     }
 
-    uint8_t *cmd_ptr = ptk_ptr + sizeof(protocol_header_t);
+    uint8_t *cmd_ptr = pkt + sizeof(db_frame_header_t);
     // parse received packet and update the motors' speeds
     switch ((uint8_t)*cmd_ptr++) {
 

--- a/apps/nrf5340_net/main.c
+++ b/apps/nrf5340_net/main.c
@@ -15,19 +15,11 @@
 #include "ipc.h"
 #include "radio.h"
 #include "rng.h"
-// Include DRV headers
-#include "tdma_client.h"
-#include "tdma_server.h"
 
 //=========================== defines ==========================================
 typedef struct {
     bool      _data_received;
     ipc_req_t _req_received;
-    // TDMA server variables
-    uint32_t           frame_duration_us;
-    uint16_t           num_clients;
-    uint16_t           table_index;
-    tdma_table_entry_t client;
 } nrf53_net_vars_t;
 
 //=========================== variables ========================================
@@ -42,22 +34,6 @@ void radio_callback(uint8_t *packet, uint8_t length) {
     mutex_lock();
     ipc_shared_data.radio.rx_pdu.length = length;
     memcpy((void *)ipc_shared_data.radio.rx_pdu.buffer, packet, length);
-    mutex_unlock();
-    _nrf53_net_vars._data_received = true;
-}
-
-void tdma_client_callback(uint8_t *packet, uint8_t length) {
-    mutex_lock();
-    ipc_shared_data.tdma_client.rx_pdu.length = length;
-    memcpy((void *)ipc_shared_data.tdma_client.rx_pdu.buffer, packet, length);
-    mutex_unlock();
-    _nrf53_net_vars._data_received = true;
-}
-
-void tdma_server_callback(uint8_t *packet, uint8_t length) {
-    mutex_lock();
-    ipc_shared_data.tdma_server.rx_pdu.length = length;
-    memcpy((void *)ipc_shared_data.tdma_server.rx_pdu.buffer, packet, length);
     mutex_unlock();
     _nrf53_net_vars._data_received = true;
 }
@@ -123,58 +99,6 @@ int main(void) {
                     db_rng_read((uint8_t *)&ipc_shared_data.rng.value);
                     break;
 
-                // TDMA Client functions
-                case DB_IPC_TDMA_CLIENT_INIT_REQ:
-                    db_tdma_client_init(&tdma_client_callback, ipc_shared_data.tdma_client.mode, ipc_shared_data.tdma_client.frequency);
-                    break;
-                case DB_IPC_TDMA_CLIENT_SET_TABLE_REQ:
-                    db_tdma_client_set_table((const tdma_client_table_t *)&ipc_shared_data.tdma_client.table_set);
-                    break;
-                case DB_IPC_TDMA_CLIENT_GET_TABLE_REQ:
-                    db_tdma_client_get_table((tdma_client_table_t *)&ipc_shared_data.tdma_client.table_get);
-                    break;
-                case DB_IPC_TDMA_CLIENT_TX_REQ:
-                    db_tdma_client_tx((uint8_t *)ipc_shared_data.tdma_client.tx_pdu.buffer, ipc_shared_data.tdma_client.tx_pdu.length);
-                    break;
-                case DB_IPC_TDMA_CLIENT_FLUSH_REQ:
-                    db_tdma_client_flush();
-                    break;
-                case DB_IPC_TDMA_CLIENT_EMPTY_REQ:
-                    db_tdma_client_empty();
-                    break;
-                case DB_IPC_TDMA_CLIENT_STATUS_REQ:
-                    ipc_shared_data.tdma_client.registration_state = db_tdma_client_get_status();
-                    break;
-
-                // TDMA Server functions
-                case DB_IPC_TDMA_SERVER_INIT_REQ:
-                    db_tdma_server_init(&tdma_server_callback, ipc_shared_data.tdma_server.mode, ipc_shared_data.tdma_server.frequency);
-                    break;
-                case DB_IPC_TDMA_SERVER_GET_TABLE_REQ:
-                    db_tdma_server_get_table_info(&_nrf53_net_vars.frame_duration_us, &_nrf53_net_vars.num_clients, &_nrf53_net_vars.table_index);
-                    ipc_shared_data.tdma_server.frame_duration_us = _nrf53_net_vars.frame_duration_us;
-                    ipc_shared_data.tdma_server.num_clients       = _nrf53_net_vars.num_clients;
-                    ipc_shared_data.tdma_server.table_index       = _nrf53_net_vars.table_index;
-                    break;
-                case DB_IPC_TDMA_SERVER_GET_CLIENT_REQ:
-                    // Copy the client info to an intermediate variable
-                    db_tdma_server_get_client_info((tdma_table_entry_t *)&_nrf53_net_vars.client, ipc_shared_data.tdma_server.client_id);
-                    // Copy the intermediate variable to the ipc shared variable
-                    ipc_shared_data.tdma_server.client_entry.client      = _nrf53_net_vars.client.client;
-                    ipc_shared_data.tdma_server.client_entry.rx_duration = _nrf53_net_vars.client.rx_duration;
-                    ipc_shared_data.tdma_server.client_entry.rx_start    = _nrf53_net_vars.client.rx_start;
-                    ipc_shared_data.tdma_server.client_entry.tx_duration = _nrf53_net_vars.client.tx_duration;
-                    ipc_shared_data.tdma_server.client_entry.tx_start    = _nrf53_net_vars.client.tx_start;
-                    break;
-                case DB_IPC_TDMA_SERVER_TX_REQ:
-                    db_tdma_server_tx((uint8_t *)ipc_shared_data.tdma_server.tx_pdu.buffer, ipc_shared_data.tdma_server.tx_pdu.length);
-                    break;
-                case DB_IPC_TDMA_SERVER_FLUSH_REQ:
-                    db_tdma_server_flush();
-                    break;
-                case DB_IPC_TDMA_SERVER_EMPTY_REQ:
-                    db_tdma_server_empty();
-                    break;
                 default:
                     break;
             }

--- a/apps/sailbot/main.c
+++ b/apps/sailbot/main.c
@@ -34,7 +34,7 @@
 #include "as5048b.h"
 
 // Include DRV headers
-#include "tdma_client.h"
+#include "frame.h"
 
 //=========================== defines =========================================
 
@@ -42,7 +42,6 @@
 #define CONTROL_LOOP_PERIOD_MS      (1000)  ///< control loop period
 #define WAYPOINT_DISTANCE_THRESHOLD (10)    ///< in meters
 
-#define DB_RADIO_FREQ             (8)      //< Set the frequency to 2408 MHz
 #define SAIL_TRIM_ANGLE_UNIT_STEP (10)     ///< unit step increase/decrease when trimming the sails
 #define TIMEOUT_CHECK_DELAY_TICKS (17000)  ///< ~500 ms delay between packet received timeout checks
 #define TIMEOUT_CHECK_DELAY_MS    (200)    ///< 200 ms delay between packet received timeout checks
@@ -120,7 +119,10 @@ int main(void) {
     _sailbot_vars.sail_trim            = 50;
 
     // Configure Radio as a receiver
-    db_tdma_client_init(&radio_callback, DB_RADIO_BLE_LR125Kbit, DB_RADIO_FREQ);
+    db_radio_init(&radio_callback, DB_RADIO_BLE_LR125Kbit);
+    db_radio_set_network_address(DB_FRAME_ACCESS_ADDR);
+    db_radio_set_frequency(DB_FRAME_DEFAULT_FREQ);
+    db_radio_rx();
 
     // Init the IMU chips
     imu_init(NULL, NULL);
@@ -155,8 +157,12 @@ int main(void) {
             lsm6ds_read_accelerometer(&_sailbot_vars.last_accelerometer);
         }
         if (_sailbot_vars.advertise) {
-            size_t length = db_protocol_advertizement_to_buffer(_sailbot_vars.radio_buffer, DB_GATEWAY_ADDRESS, SailBot);
-            db_tdma_client_tx(_sailbot_vars.radio_buffer, length);
+            size_t length                        = db_frame_header_to_buffer(_sailbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+            _sailbot_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
+            _sailbot_vars.radio_buffer[length++] = SailBot;
+            db_radio_disable();
+            db_radio_tx(_sailbot_vars.radio_buffer, length);
+            db_radio_rx();
 
             _sailbot_vars.advertise = false;
         }
@@ -185,25 +191,28 @@ int main(void) {
  *
  */
 void radio_callback(uint8_t *packet, uint8_t length) {
-    (void)length;
-    uint8_t                 *ptk_ptr = packet;
-    const protocol_header_t *header  = (const protocol_header_t *)ptk_ptr;
+    if (length < sizeof(db_frame_header_t) + 1) {
+        return;
+    }
+    const db_frame_header_t *header = (const db_frame_header_t *)packet;
 
     // timestamp the arrival of the packet
     _sailbot_vars.ts_last_packet_received = db_timer_ticks(TIMER_DEV);
 
-    // Check destination address matches
-    if (header->dst != DB_BROADCAST_ADDRESS && header->dst != db_device_id()) {
+    // Drop frames addressed elsewhere
+    if (header->dst != DB_FRAME_DST_BROADCAST && header->dst != db_device_id()) {
         return;
     }
 
-    // Check version is compatible
-    if (header->version != DB_FIRMWARE_VERSION) {
+    // Drop wrong version / wrong upper-layer protocol
+    if (header->version != DB_FRAME_VERSION ||
+        header->type != DB_FRAME_TYPE_DATA ||
+        header->next_proto != DB_FRAME_NEXT_PROTO) {
         return;
     }
 
     // Process the command received
-    uint8_t *cmd_ptr = ptk_ptr + sizeof(protocol_header_t);
+    uint8_t *cmd_ptr = packet + sizeof(db_frame_header_t);
     switch ((uint8_t)*cmd_ptr++) {
         case DB_PROTOCOL_CMD_MOVE_RAW:
         {
@@ -310,7 +319,7 @@ static void _send_data(const nmea_gprmc_t *data, uint16_t heading, uint16_t wind
     int32_t latitude  = (int32_t)(data->latitude * 1e6);
     int32_t longitude = (int32_t)(data->longitude * 1e6);
 
-    size_t length                        = db_protocol_header_to_buffer(_sailbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+    size_t length                        = db_frame_header_to_buffer(_sailbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
     _sailbot_vars.radio_buffer[length++] = DB_PROTOCOL_SAILBOT_DATA;
 
     // define the offsets based on the order of the data
@@ -337,7 +346,9 @@ static void _send_data(const nmea_gprmc_t *data, uint16_t heading, uint16_t wind
 
     length += heading_size + latitude_size + longitude_size + wind_angle_size + rudder_angle_size + sail_trim_size;
 
-    db_tdma_client_tx(_sailbot_vars.radio_buffer, length);
+    db_radio_disable();
+    db_radio_tx(_sailbot_vars.radio_buffer, length);
+    db_radio_rx();
 }
 
 static int8_t map_error_to_rudder_angle(float error) {

--- a/apps/sailbot/main.c
+++ b/apps/sailbot/main.c
@@ -157,9 +157,7 @@ int main(void) {
             lsm6ds_read_accelerometer(&_sailbot_vars.last_accelerometer);
         }
         if (_sailbot_vars.advertise) {
-            size_t length                        = db_frame_header_to_buffer(_sailbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
-            _sailbot_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
-            _sailbot_vars.radio_buffer[length++] = SailBot;
+            size_t length = db_protocol_advertizement_to_buffer(_sailbot_vars.radio_buffer, DB_GATEWAY_ADDRESS, SailBot);
             db_radio_disable();
             db_radio_tx(_sailbot_vars.radio_buffer, length);
             db_radio_rx();
@@ -319,7 +317,7 @@ static void _send_data(const nmea_gprmc_t *data, uint16_t heading, uint16_t wind
     int32_t latitude  = (int32_t)(data->latitude * 1e6);
     int32_t longitude = (int32_t)(data->longitude * 1e6);
 
-    size_t length                        = db_frame_header_to_buffer(_sailbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+    size_t length                        = db_protocol_header_to_buffer(_sailbot_vars.radio_buffer, DB_GATEWAY_ADDRESS);
     _sailbot_vars.radio_buffer[length++] = DB_PROTOCOL_SAILBOT_DATA;
 
     // define the offsets based on the order of the data

--- a/apps/xgo/main.c
+++ b/apps/xgo/main.c
@@ -22,7 +22,7 @@
 #include "timer_hf.h"
 #include "uart.h"
 // Include DRV headers
-#include "tdma_client.h"
+#include "frame.h"
 
 //=========================== defines ==========================================
 
@@ -31,7 +31,6 @@
 #define TIMEOUT_CHECK_DELAY_US     (1000 * 500UL)  ///< 500 ms delay between packet received timeout checks
 
 #define XGO_RADIO_BUFFER_MAX_BYTES (255U)
-#define XGO_RADIO_FREQ             (8)  //< Set the frequency to 2408 MHz
 #define XGO_UART_BAUDRATE          (115200U)
 #define XGO_UART_MAX_BYTES         (64U)
 
@@ -203,23 +202,26 @@ static void _advertize(void) {
 }
 
 static void _radio_callback(uint8_t *pkt, uint8_t len) {
-    (void)len;
+    if (len < sizeof(db_frame_header_t) + 1) {
+        return;
+    }
 
     _xgo_vars.packet_received = true;
 
-    uint8_t                 *ptk_ptr = pkt;
-    const protocol_header_t *header  = (const protocol_header_t *)ptk_ptr;
-    // Check destination address is matching
-    if (header->dst != DB_BROADCAST_ADDRESS && header->dst != _xgo_vars.device_id) {
+    const db_frame_header_t *header = (const db_frame_header_t *)pkt;
+    // Drop frames addressed elsewhere
+    if (header->dst != DB_FRAME_DST_BROADCAST && header->dst != _xgo_vars.device_id) {
         return;
     }
 
-    // Check version is supported
-    if (header->version != DB_FIRMWARE_VERSION) {
+    // Drop wrong version / wrong upper-layer protocol
+    if (header->version != DB_FRAME_VERSION ||
+        header->type != DB_FRAME_TYPE_DATA ||
+        header->next_proto != DB_FRAME_NEXT_PROTO) {
         return;
     }
 
-    uint8_t *cmd_ptr = ptk_ptr + sizeof(protocol_header_t);
+    uint8_t *cmd_ptr = pkt + sizeof(db_frame_header_t);
     // parse received packet and execute the command
     switch ((uint8_t)*cmd_ptr++) {
         case DB_PROTOCOL_CMD_MOVE_RAW:
@@ -266,7 +268,10 @@ static void _radio_callback(uint8_t *pkt, uint8_t len) {
 //=========================== main =============================================
 
 int main(void) {
-    db_tdma_client_init(&_radio_callback, DB_RADIO_BLE_1MBit, XGO_RADIO_FREQ);
+    db_radio_init(&_radio_callback, DB_RADIO_BLE_1MBit);
+    db_radio_set_network_address(DB_FRAME_ACCESS_ADDR);
+    db_radio_set_frequency(DB_FRAME_DEFAULT_FREQ);
+    db_radio_rx();
 
     // Retrieve the device id once at startup
     _xgo_vars.device_id = db_device_id();
@@ -285,8 +290,12 @@ int main(void) {
         }
 
         if (_xgo_vars.advertize) {
-            size_t length = db_protocol_advertizement_to_buffer(_xgo_vars.radio_buffer, DB_GATEWAY_ADDRESS, XGO);
-            db_tdma_client_tx(_xgo_vars.radio_buffer, length);
+            size_t length                    = db_frame_header_to_buffer(_xgo_vars.radio_buffer, DB_GATEWAY_ADDRESS);
+            _xgo_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
+            _xgo_vars.radio_buffer[length++] = XGO;
+            db_radio_disable();
+            db_radio_tx(_xgo_vars.radio_buffer, length);
+            db_radio_rx();
             _xgo_vars.advertize = false;
         }
 

--- a/apps/xgo/main.c
+++ b/apps/xgo/main.c
@@ -290,9 +290,7 @@ int main(void) {
         }
 
         if (_xgo_vars.advertize) {
-            size_t length                    = db_frame_header_to_buffer(_xgo_vars.radio_buffer, DB_GATEWAY_ADDRESS);
-            _xgo_vars.radio_buffer[length++] = DB_PROTOCOL_ADVERTISEMENT;
-            _xgo_vars.radio_buffer[length++] = XGO;
+            size_t length = db_protocol_advertizement_to_buffer(_xgo_vars.radio_buffer, DB_GATEWAY_ADDRESS, XGO);
             db_radio_disable();
             db_radio_tx(_xgo_vars.radio_buffer, length);
             db_radio_rx();


### PR DESCRIPTION
Replaces the TDMA link layer for all bare DotBot apps with a direct
bare-radio path plus a mari-compatible 21-byte wire header from the new
`drv/frame.h` (added in DotBots/DotBot-libs#21). TDMA was a swarm-
coordination placeholder that Mari now owns properly; keeping it around
for bare apps would force the host to maintain a third frame vocabulary
alongside Mari + Swarmit. By matching Mari's wire layout byte-for-byte,
the rewritten `dotbot_gateway` wraps received frames as `MARI_EDGE_DATA`
UART events and PyDotBot's MarilibEdge adapter (which now dispatches by
`next_proto`) handles them with no special case.

Scope of the per-app migrations:

- `apps/dotbot`, `apps/sailbot`, `apps/freebot`, `apps/xgo`,
  `apps/lh2_mini_mote_app`, `apps/lh2_mini_mote_test`: drop
  `drv/tdma_client`, talk to `drv/radio` directly, write the 21-byte
  header + the existing payload-type tag + the same payload bytes the
  legacy `protocol_*_to_buffer` helpers produced. RX gates by `dst`,
  `version`, `type`, and `next_proto`. Sailbot keeps its `LR125Kbit`
  PHY (paired with the LR gateway, not the standard one); the rest
  stay at `1MBit`.
- `apps/dotbot_gateway`: drops `drv/tdma_server`, listens on bare
  radio, and on the UART side speaks the MarilibEdge event protocol
  — emits `[DB_EDGE_EVENT_DATA (=3)][frame bytes]` per received frame
  and accepts the same shape from the host for TX requests. Only
  `NODE_DATA` event type is wired up; `NODE_JOINED`/`KEEPALIVE`/
  `GATEWAY_INFO` are skipped since bare radio has no joining and the
  host treats first-seen `src` in a data frame as discovery.

Worth a second look:

- The radio still runs `DB_RADIO_BLE_1MBit` at 2408 MHz (`freq = 8` from
  `DB_FRAME_DEFAULT_FREQ`), identical to what TDMA used here. Sailbot
  keeps its long-range PHY independently.
- BLE access address is `DB_FRAME_ACCESS_ADDR = 0xDB12DB12`, distinct
  from Mari's `0x12345678` — Mari nodes and bare DotBots ignore each
  other at the radio peripheral filter, no software-level coexistence.
- This PR bumps the `dotbot-libs` submodule to a SHA on the geonnave
  fork branch (DotBots/DotBot-libs#21). CI's submodule fetch will fail
  until #21 merges to `develop`; the SHA becomes reachable from
  `origin` at that point and the next CI run greens.

Validated end-to-end on hardware: dotbot v3 + nrf52840dk gateway, bare
radio frames at 2 Hz advertizement rate, wrapped as
`[03][21B header][payload]` `MARI_EDGE_DATA` events over HDLC at 1 Mbps
UART, parsed by PyDotBot's `MarilibEdgeAdapter` (`next_proto =
DOTBOT_APP` strict gate). Each frame field decoded correctly: version=3,
type=DATA(16), network_id=0xD0B0, next_proto=DOTBOT_APP(0x11),
src=FICR-derived 64-bit id, and the advertisement payload (battery,
position, encoders, waypoints) bytes unchanged from the legacy format.

TDMA driver deprecation/removal in `dotbot-libs` is a follow-up PR
(no consumer references `drv/tdma_*` anymore after this lands, but the
deprecation notice / file delete is a separate cleanup).