### PR TITLE
apps: harden dotbot against waypoint stack-smash + ISR flag race

### DIFF
--- a/apps-sandbox/dotbot/main.c
+++ b/apps-sandbox/dotbot/main.c
@@ -128,6 +128,9 @@ static void _rx_data_callback(const uint8_t *pkt, size_t len) {
             memcpy(&threshold, cmd_ptr, sizeof(uint16_t));
             cmd_ptr += sizeof(uint16_t);
             uint8_t count = (uint8_t)*cmd_ptr++;
+            if (count > DB_MAX_WAYPOINTS) {
+                count = DB_MAX_WAYPOINTS;
+            }
             memcpy(&_dotbot_vars.waypoints.points, cmd_ptr, count * sizeof(protocol_lh2_location_t));
             coordinate_t waypoints[DB_MAX_WAYPOINTS];
             for (uint8_t i = 0; i < count; i++) {

--- a/apps-sandbox/dotbot/main.c
+++ b/apps-sandbox/dotbot/main.c
@@ -51,9 +51,9 @@ typedef struct {
     position_2d_t            last_position;                      ///< Last computed LH2 location received
     protocol_control_mode_t  control_mode;                       ///< Remote control mode
     protocol_lh2_waypoints_t waypoints;                          ///< List of waypoints
-    bool                     update_control_loop;                ///< Whether the control loop need an update
-    bool                     advertize;                          ///< Whether an advertize packet should be sent
-    bool                     update_position;                    ///< Whether position must be updated
+    volatile bool            update_control_loop;                ///< Whether the control loop need an update
+    volatile bool            advertize;                          ///< Whether an advertize packet should be sent
+    volatile bool            update_position;                    ///< Whether position must be updated
     uint64_t                 device_id;                          ///< Device ID of the DotBot
 } dotbot_vars_t;
 

--- a/apps/dotbot/main.c
+++ b/apps/dotbot/main.c
@@ -52,9 +52,9 @@ typedef struct {
     uint8_t                  radio_buffer[DB_BUFFER_MAX_BYTES];  ///< Internal buffer that contains the command to send (from buttons)
     protocol_control_mode_t  control_mode;                       ///< Remote control mode
     protocol_lh2_waypoints_t waypoints;                          ///< List of waypoints
-    bool                     update_control_loop;                ///< Whether the control loop need an update
-    bool                     advertize;                          ///< Whether an advertize packet should be sent
-    bool                     update_lh2;                         ///< Whether LH2 data must be processed
+    volatile bool            update_control_loop;                ///< Whether the control loop need an update
+    volatile bool            advertize;                          ///< Whether an advertize packet should be sent
+    volatile bool            update_lh2;                         ///< Whether LH2 data must be processed
     uint64_t                 device_id;                          ///< Device ID of the DotBot
     double                   coordinates[2];                     ///< x, y coordinates of the robot
 } dotbot_vars_t;

--- a/apps/dotbot/main.c
+++ b/apps/dotbot/main.c
@@ -142,6 +142,9 @@ static void radio_callback(uint8_t *pkt, uint8_t len) {
             memcpy(&threshold, cmd_ptr, sizeof(uint16_t));
             cmd_ptr += sizeof(uint16_t);
             uint8_t count = (uint8_t)*cmd_ptr++;
+            if (count > DB_MAX_WAYPOINTS) {
+                count = DB_MAX_WAYPOINTS;
+            }
             memcpy(&_dotbot_vars.waypoints.points, cmd_ptr, count * sizeof(protocol_lh2_location_t));
             coordinate_t waypoints[DB_MAX_WAYPOINTS];
             for (uint8_t i = 0; i < count; i++) {


### PR DESCRIPTION
## Summary

Two crash-protective fixes in both the sandbox (`apps-sandbox/dotbot/`) and bare (`apps/dotbot/`) DotBot apps. Same shape applied to each, one commit per (app × fix).

- **LH2 waypoint count clamp**. `DB_PROTOCOL_LH2_WAYPOINTS` carries a 1-byte `count` from the host; it was fed straight to `memcpy` and to a loop indexing a 16-entry stack-local `waypoints[]`. A bogus count (host CLI bug, radio bit-flip, hand-crafted test frame) smashes the BSS waypoint array and the Cortex-M return address — HardFault/SecureFault reset on the next return. Clamps `count` to `DB_MAX_WAYPOINTS` (16) before the memcpy and the copy loop, mirroring the canonical pattern in `dotbot-libs/drv/control_loop/control_loop.c:100-101`.
- **Mark ISR-set flags `volatile`**. `update_control_loop`, `advertize`, and `update_position` (sandbox) / `update_lh2` (bare) are set by timer ISRs and read+cleared in the main loop. Without `volatile`, the compiler can cache the read at `-Os` and never see the ISR's update — main loop stalls, bot appears frozen until reset.

Companion to swarmit's `demo-crash-protection` PR which addresses the same demo-crash class on the bootloader side (LH2 calibration hardening + OTA chunk race + IPC memory barrier).

## Test plan

- [x] `BUILD_TARGET=dotbot-v3 BUILD_CONFIG=Release make dotbot` (bare) — green via local SES.
- [x] `BUILD_TARGET=sandbox-dotbot-v3 BUILD_CONFIG=Release make dotbot` (sandbox) — green via local SES.
- [ ] HIL: flash bare dotbot v3, drive via PyDotBot, exercise waypoint navigation with a normal (≤16) mission — no behavior change.
- [ ] HIL: flash sandbox dotbot v3 via swarmit, exercise waypoint navigation — no behavior change.
- [ ] HIL: send a hand-crafted `LH2_WAYPOINTS` packet with `count = 100` to a bare bot — bot should clamp to 16 silently, no reset.
- [ ] HIL: run a multi-minute teleop demo — bot remains responsive (no main-loop freeze from volatile-missing).