### PR TITLE
makefile: BUILD_MODE knob + list-targets + lh2_calibration artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,16 +129,15 @@ list-projects:
 	@echo "\e[1mAvailable projects:\e[0m"
 	@echo $(PROJECTS) | tr ' ' '\n'
 
-# Source of truth for valid BUILD_TARGET values. Used by tooling that
-# wants to validate target names without parsing the ifeq cascade above
-# (see dotbot CLI's `dotbot fw targets` / `dotbot swarm fw targets`).
-BARE_TARGETS = dotbot-v1 dotbot-v2 dotbot-v3 \
-               nrf52833dk nrf52840dk \
-               nrf5340dk-app nrf5340dk-net \
-               sailbot-v1 freebot-v1.0 \
-               lh2-mini-mote \
-               xgo-v1 xgo-v2
-SANDBOX_TARGETS = sandbox-dotbot-v2 sandbox-dotbot-v3 sandbox-nrf5340dk
+# Source of truth for valid BUILD_TARGET values. Derived from the
+# .emProject files at the repo root so adding/removing a target is just
+# adding/removing the .emProject — no parallel list to maintain. Used
+# by tooling that validates target names without parsing the ifeq
+# cascade above (see dotbot CLI's `dotbot fw targets` /
+# `dotbot swarm fw targets`).
+_EMPROJECTS = $(sort $(patsubst %.emProject,%,$(notdir $(wildcard *.emProject))))
+BARE_TARGETS    = $(filter-out sandbox-%,$(_EMPROJECTS))
+SANDBOX_TARGETS = $(filter sandbox-%,$(_EMPROJECTS))
 
 list-targets:
 	@echo $(BARE_TARGETS) $(SANDBOX_TARGETS) | tr ' ' '\n'

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ VERBOSE_OPTS ?= -verbose -echo
 ifeq ($(QUIET),1)
   VERBOSE_OPTS =
 endif
+BUILD_MODE ?= -rebuild
 
 # Sandbox (TrustZone non-secure) apps live under apps-sandbox/ and are flashed
 # over the air with swarmit, which consumes a raw .bin. Bare apps live under
@@ -121,7 +122,7 @@ all: $(PROJECTS)
 
 $(PROJECTS):
 	@echo "\e[1mBuilding project $@\e[0m"
-	"$(SEGGER_DIR)/bin/emBuild" $(PROJECT_FILE) -project $@ -config $(BUILD_CONFIG) $(PACKAGES_DIR_OPT) -rebuild $(VERBOSE_OPTS)
+	"$(SEGGER_DIR)/bin/emBuild" $(PROJECT_FILE) -project $@ -config $(BUILD_CONFIG) $(PACKAGES_DIR_OPT) $(BUILD_MODE) $(VERBOSE_OPTS)
 	@echo "\e[1mDone\e[0m\n"
 
 list-projects:

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,14 @@ SRCS ?= $(foreach dir,$(DIRS),$(shell find $(dir) -name "*.[c|h]"))
 CLANG_FORMAT ?= clang-format
 CLANG_FORMAT_TYPE ?= file
 
-ARTIFACT_BASE = $(foreach app,$(ARTIFACT_PROJECTS),$(APPS_DIR)/$(app)/Output/$(BUILD_TARGET)/$(BUILD_CONFIG)/Exe/$(app)-$(BUILD_TARGET))
+# SES's `$(BuildTarget)` macro inside the .emProject files is hardcoded
+# to the bare board name (e.g. sandbox-dotbot-v3.emProject sets
+# BuildTarget=dotbot-v3), so on-disk Output dirs use the bare board name
+# regardless of `sandbox-` prefix. _OUTPUT_TARGET mirrors that — strips
+# the prefix for the artifact path lookup. Without this, `make artifacts
+# BUILD_TARGET=sandbox-*` silently references paths that don't exist.
+_OUTPUT_TARGET = $(patsubst sandbox-%,%,$(BUILD_TARGET))
+ARTIFACT_BASE = $(foreach app,$(ARTIFACT_PROJECTS),$(APPS_DIR)/$(app)/Output/$(_OUTPUT_TARGET)/$(BUILD_CONFIG)/Exe/$(app)-$(_OUTPUT_TARGET))
 ARTIFACTS = $(addsuffix .$(ARTIFACT_FMT),$(ARTIFACT_BASE))
 
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 
 ifneq (,$(filter dotbot-v2 dotbot-v3,$(BUILD_TARGET)))
   PROJECTS := $(filter-out dotbot_gateway dotbot_gateway_lr sailbot xgo nrf5340_net freebot lh2_mini_mote%,$(PROJECTS))
-  ARTIFACT_PROJECTS := dotbot
+  ARTIFACT_PROJECTS := dotbot lh2_calibration
 endif
 
 # remove incompatible apps (nrf5340, sailbot, gateway, dotbot) for lh2-mini-mote builds

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,47 @@ list-projects:
 	@echo "\e[1mAvailable projects:\e[0m"
 	@echo $(PROJECTS) | tr ' ' '\n'
 
+# Source of truth for valid BUILD_TARGET values. Used by tooling that
+# wants to validate target names without parsing the ifeq cascade above
+# (see dotbot CLI's `dotbot fw targets` / `dotbot swarm fw targets`).
+BARE_TARGETS = dotbot-v1 dotbot-v2 dotbot-v3 \
+               nrf52833dk nrf52840dk \
+               nrf5340dk-app nrf5340dk-net \
+               sailbot-v1 freebot-v1.0 \
+               lh2-mini-mote \
+               xgo-v1 xgo-v2
+SANDBOX_TARGETS = sandbox-dotbot-v2 sandbox-dotbot-v3 sandbox-nrf5340dk
+
+list-targets:
+	@echo $(BARE_TARGETS) $(SANDBOX_TARGETS) | tr ' ' '\n'
+
+help:
+	@echo "DotBot-firmware Makefile"
+	@echo ""
+	@echo "Usage:  BUILD_TARGET=<target> BUILD_CONFIG=<Debug|Release> make [project|target]"
+	@echo ""
+	@echo "Variables:"
+	@echo "  BUILD_TARGET   e.g. dotbot-v3, sandbox-dotbot-v3, nrf5340dk-app"
+	@echo "  BUILD_CONFIG   Debug | Release    (default: Debug)"
+	@echo "  BUILD_MODE     -build | -rebuild  (default: -rebuild)"
+	@echo "  QUIET          0 | 1              (default: 0)"
+	@echo "  SEGGER_DIR     Path to SES install root"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all            Build every app available for BUILD_TARGET (default)"
+	@echo "  <project>      Build a single project (see 'make list-projects')"
+	@echo "  artifacts      Build canonical apps + copy outputs to artifacts/"
+	@echo "  clean          SES clean for current BUILD_TARGET + BUILD_CONFIG"
+	@echo "  distclean      clean + rm artifacts/"
+	@echo "  list-projects  List projects available for current BUILD_TARGET"
+	@echo "  list-targets   List valid BUILD_TARGET values (bare + sandbox)"
+	@echo "  format         clang-format in place"
+	@echo "  check-format   clang-format --dry-run"
+	@echo "  docker         Run a target inside the aabadie/dotbot:latest container"
+	@echo "  doc            Build Sphinx HTML docs"
+	@echo ""
+	@echo "Run 'make list-projects BUILD_TARGET=<target>' to see what builds where."
+
 clean:
 	"$(SEGGER_DIR)/bin/emBuild" $(PROJECT_FILE) -config $(BUILD_CONFIG) -clean $(VERBOSE_OPTS)
 

--- a/Makefile
+++ b/Makefile
@@ -112,14 +112,7 @@ SRCS ?= $(foreach dir,$(DIRS),$(shell find $(dir) -name "*.[c|h]"))
 CLANG_FORMAT ?= clang-format
 CLANG_FORMAT_TYPE ?= file
 
-# SES's `$(BuildTarget)` macro inside the .emProject files is hardcoded
-# to the bare board name (e.g. sandbox-dotbot-v3.emProject sets
-# BuildTarget=dotbot-v3), so on-disk Output dirs use the bare board name
-# regardless of `sandbox-` prefix. _OUTPUT_TARGET mirrors that — strips
-# the prefix for the artifact path lookup. Without this, `make artifacts
-# BUILD_TARGET=sandbox-*` silently references paths that don't exist.
-_OUTPUT_TARGET = $(patsubst sandbox-%,%,$(BUILD_TARGET))
-ARTIFACT_BASE = $(foreach app,$(ARTIFACT_PROJECTS),$(APPS_DIR)/$(app)/Output/$(_OUTPUT_TARGET)/$(BUILD_CONFIG)/Exe/$(app)-$(_OUTPUT_TARGET))
+ARTIFACT_BASE = $(foreach app,$(ARTIFACT_PROJECTS),$(APPS_DIR)/$(app)/Output/$(BUILD_TARGET)/$(BUILD_CONFIG)/Exe/$(app)-$(BUILD_TARGET))
 ARTIFACTS = $(addsuffix .$(ARTIFACT_FMT),$(ARTIFACT_BASE))
 
 

--- a/sandbox-dotbot-v2.emProject
+++ b/sandbox-dotbot-v2.emProject
@@ -49,7 +49,7 @@
     linker_printf_fp_enabled="Float"
     linker_printf_width_precision_supported="Yes"
     linker_section_placement_file="$(ProjectDir)/../$(Target)_flash_placement.xml"
-    macros="BuildTarget=dotbot-v2;DeviceFamily=nRF;Target=nRF5340_xxAA_Application;Placement=Flash"
+    macros="BuildTarget=sandbox-dotbot-v2;DeviceFamily=nRF;Target=nRF5340_xxAA_Application;Placement=Flash"
     project_type="Executable"
     target_reset_script="Reset();"
     target_script_file="$(ProjectDir)/../../dotbot-libs/nRF/Scripts/nRF_Target.js"

--- a/sandbox-dotbot-v3.emProject
+++ b/sandbox-dotbot-v3.emProject
@@ -49,7 +49,7 @@
     linker_printf_fp_enabled="Float"
     linker_printf_width_precision_supported="Yes"
     linker_section_placement_file="$(ProjectDir)/../$(Target)_flash_placement.xml"
-    macros="BuildTarget=dotbot-v3;DeviceFamily=nRF;Target=nRF5340_xxAA_Application;Placement=Flash"
+    macros="BuildTarget=sandbox-dotbot-v3;DeviceFamily=nRF;Target=nRF5340_xxAA_Application;Placement=Flash"
     project_type="Executable"
     target_reset_script="Reset();"
     target_script_file="$(ProjectDir)/../../dotbot-libs/nRF/Scripts/nRF_Target.js"

--- a/sandbox-nrf5340dk.emProject
+++ b/sandbox-nrf5340dk.emProject
@@ -49,7 +49,7 @@
     linker_printf_fp_enabled="Float"
     linker_printf_width_precision_supported="Yes"
     linker_section_placement_file="$(ProjectDir)/../$(Target)_flash_placement.xml"
-    macros="BuildTarget=nrf5340dk;DeviceFamily=nRF;Target=nRF5340_xxAA_Application;Placement=Flash"
+    macros="BuildTarget=sandbox-nrf5340dk;DeviceFamily=nRF;Target=nRF5340_xxAA_Application;Placement=Flash"
     project_type="Executable"
     target_reset_script="Reset();"
     target_script_file="$(ProjectDir)/../../dotbot-libs/nRF/Scripts/nRF_Target.js"


### PR DESCRIPTION
Four backwards-compat Makefile additions, all consumed downstream by
PyDotBot's `dotbot fw build` CLI.

## `BUILD_MODE` knob (incremental builds)

`BUILD_MODE ?= -rebuild` parameterizes the hardcoded `-rebuild` flag in
the `$(PROJECTS)` recipe. The default preserves prior behavior for
bare `make` callers; `make BUILD_MODE=-build <project>` now does an
incremental SES build, dropping the edit/build loop from ~90s to
~5–10s. The `dotbot fw build` CLI defaults to passing
`BUILD_MODE=-build` and exposes `--rebuild` to opt back into
full-rebuild behavior. CI matrix jobs that don't set `BUILD_MODE`
keep getting the prior `-rebuild` semantics.

## `list-targets` and `help` rules

`make list-targets` and `make help` are new no-recipe rules.
`list-targets` prints every supported `BUILD_TARGET` value (bare +
sandbox), backed by new `BARE_TARGETS` / `SANDBOX_TARGETS` make
variables that are **derived at Make time from the `.emProject` files
at the repo root** via `$(wildcard *.emProject)` — so adding or
removing a target is just adding or removing the `.emProject`, no
parallel list to maintain. This becomes the source of truth that
downstream tooling's hardcoded target enum has to match; a parity
test on the PyDotBot side (`set(BARE_TARGETS) | {sandbox-<b>} ==
set(make list-targets)`) catches drift the day someone adds
`dotbot-v4` and forgets the CLI. `make help` is a self-contained
one-screen reference for the variables and targets a developer can
pass.

## `lh2_calibration` collected in `dotbot-v2`/`dotbot-v3` artifacts

The calibration app was folded in via #407 (now `apps/lh2_calibration/`)
but never added to the collected-artifact list. It builds fine for
every robot/devkit target — `make list-projects` shows it — but
`make artifacts` was silently dropping it. v2/v3 (the active robots)
now collect `lh2_calibration-dotbot-v{2,3}.hex` alongside the main
`dotbot` app. v1 stays opt-in via `make … lh2_calibration` /
`dotbot fw build dotbot-v1 --app lh2_calibration` since it's
deprecation-warned in CI.

## Validation

- `make help` and `make list-targets` print the expected output.
- `make list-targets` output is byte-identical to a hardcoded list
  of the current `.emProject` files (confirmed by `diff` against
  `ls *.emProject | sed 's/\.emProject$//'`).
- `make -n artifacts BUILD_TARGET=dotbot-v3` shows both
  `dotbot-dotbot-v3.hex` and `lh2_calibration-dotbot-v3.hex` being
  copied to `artifacts/`; v1 unchanged (still just `dotbot`).
- `make BUILD_TARGET=dotbot-v3 list-projects` still works (regression
  check on the existing rule).
- End-to-end through `dotbot fw clean dotbot-v3` (in the parallel
  PyDotBot PR), which invokes
  `make BUILD_TARGET=dotbot-v3 BUILD_CONFIG=Release QUIET=1
  BUILD_MODE=-build clean` and reaches `emBuild ... -clean` cleanly.
- CI matrix behavior is unchanged: no job sets `BUILD_MODE`, so the
  `-rebuild` default fires everywhere it did before; CI's
  `artifacts-*` upload now picks up `lh2_calibration-dotbot-v{2,3}.hex`
  as a new release asset.