### PR TITLE
apps/lh2_calibration: build Release at -O0 to work around -O2 bug

### DIFF
--- a/apps/apps-lh2-calibration.emProject
+++ b/apps/apps-lh2-calibration.emProject
@@ -6,6 +6,9 @@
       project_dependencies="00bsp_dotbot_board(bsp);00bsp_dotbot_lh2(bsp);00drv_dotbot_hdlc(drv);00bsp_uart(bsp);00bsp_timer(bsp)"
       project_directory="lh2_calibration"
       project_type="Executable" />
+    <configuration
+      Name="Release"
+      gcc_optimization_level="None" />
     <folder Name="Setup">
       <file file_name="$(ProjectDir)/../../dotbot-libs/nRF/Setup/$(Target)_flash_placement.xml" />
       <file file_name="$(ProjectDir)/../../dotbot-libs/nRF/Setup/$(Target)_MemoryMap.xml">


### PR DESCRIPTION
The Release (`-O2`) build of `lh2_calibration` runs but emits no LH2 data over UART, while the Debug build works normally. This adds a per-project Release override so only this app builds at `-O0`; the shared drivers and the other apps in the `dotbot-v3` solution stay at `-O2`.

Flashing was ruled out first: the same `dotbot device flash` path streams data from the Debug hex but not from the Release hex, and `nrfjprog --recover` + `--chiperase` on the Release hex made no difference. A bisection then isolated the optimizer as the trigger - a Release build with `NDEBUG` kept but optimization set to `None` works.

This is a workaround, not a root-cause fix. The underlying `-O2` codegen bug, plus two latent ISR-shared-without-`volatile` spots found while investigating, are tracked in #414.

Validated on the bench: the scoped `-O0` Release build flashes and `dotbot run lh2-calibration collect` streams LH2 points.
